### PR TITLE
Refactor code coverage command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
                   cargo llvm-cov \
                     --all-features --workspace \
                     --include-build-script \
-                    --lcov --output-path lcov.info
+                    --lcov --output-path lcov.info \
                     --ignore-filename-regex \
                     '^\..*|^dev/.*|^tests/.*|^C[LaHO].*|.*\.toml$|.*\.pkl$|.*\.license$|.*\.spdx$|.*\.md$|benches/.*|.*long_about\.rs$|scripts/.*$'
             - name: Upload coverage to Codecov


### PR DESCRIPTION
This pull request updates the code coverage generation step in the CI workflow to exclude additional files and directories from coverage reports. This helps ensure that only relevant source code is measured for test coverage.

**CI workflow improvements:**

* Updated the `cargo llvm-cov` command in `.github/workflows/ci.yml` to use the `--ignore-filename-regex` option, excluding files and directories such as hidden files, `dev/`, `tests/`, `benches/`, `scripts/`, and various file types (e.g., `.toml`, `.md`, `.license`) from coverage calculation.Refactor code coverage generation command for clarity and add filename ignore patterns.