### PR TITLE
🧪 implement missing tests for SubmoduleEntry::is_remote

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1259,6 +1259,14 @@ mod tests {
 
         entry.url = None;
         assert!(!entry.is_remote());
+
+        // Protocol not at start
+        entry.url = Some("/path/to/https://repo".to_string());
+        assert!(!entry.is_remote());
+
+        // Minimal protocol
+        entry.url = Some("https://".to_string());
+        assert!(entry.is_remote());
     }
 
     #[test]
@@ -2109,5 +2117,25 @@ active = true
         let config = Config::default();
         let data = config.data();
         assert!(data.is_ok());
+    }
+
+    #[test]
+    fn test_config_submodule_remote_check() {
+        let mut config = Config::default();
+        let entry = SubmoduleEntry::new(
+            Some("https://github.com/user/repo".to_string()),
+            Some("libs/repo".to_string()),
+            None,
+            None,
+            None,
+            None,
+            Some(true),
+            None,
+            None,
+        );
+        config.add_submodule("repo".to_string(), entry);
+
+        let retrieved = config.get_submodule("repo").expect("submodule should exist");
+        assert!(retrieved.is_remote());
     }
 }


### PR DESCRIPTION
The testing gap for `SubmoduleEntry::is_remote` in `src/config.rs` has been addressed by enhancing existing unit tests and adding a new integration-style test.

🎯 **What:** The testing gap addressed: `is_remote` method was missing comprehensive tests for edge cases and verification through the main `Config` struct.
📊 **Coverage:** 
- Added an assertion to `test_entry_is_remote` to verify that a path containing but not starting with a protocol (e.g., `'/path/to/https://repo'`) returns `false`.
- Added an assertion to `test_entry_is_remote` to verify that a minimal protocol string (e.g., `"https://"`) returns `true`.
- Added a new test function `test_config_submodule_remote_check` that creates a `Config` instance, adds a `SubmoduleEntry` with an `https` URL, and asserts that `is_remote()` returns `true` for that entry retrieved from the config.
✨ **Result:** Improved test coverage for submodule remote identification logic, ensuring robustness against malformed URLs and correct integration with the project's main configuration structure.

---
*PR created automatically by Jules for task [2191209411888295874](https://jules.google.com/task/2191209411888295874) started by @bashandbone*