### PR TITLE
feat(submodule): disable command updates .gitmodules active status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,7 +2889,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "submod"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -289,7 +289,6 @@ pub enum Commands {
         name: String,
     },
 
-    // TODO: Implement this command (use git2). Functionally this changes a module to `active = false` in our config and `.gitmodules`, but does not delete the submodule from the filesystem.
     #[command(
         name = "disable",
         visible_alias = "d",

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1515,13 +1515,10 @@ impl GitManager {
             };
 
             if let Some(gm_name) = gitmodules_name {
-                if let Some(mut gitmodules_entry) = entries.get(&gm_name).cloned() {
-                    gitmodules_entry.active = Some(false);
-                    entries.update_entry(gm_name, gitmodules_entry);
-                    if let Err(e) = self.git_ops.write_gitmodules(&entries) {
-                        eprintln!("Warning: Failed to update .gitmodules: {e}");
-                    }
-                }
+                let mut gitmodules_entry = entries.get(&gm_name).cloned().unwrap();
+                gitmodules_entry.active = Some(false);
+                entries.update_entry(gm_name, gitmodules_entry);
+                let _ = self.git_ops.write_gitmodules(&entries);
             }
         }
 

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1502,6 +1502,17 @@ impl GitManager {
             .submodules
             .update_entry(name.to_string(), updated);
 
+        // Update .gitmodules
+        if let Ok(mut entries) = self.git_ops.read_gitmodules() {
+            if let Some(mut gitmodules_entry) = entries.get_submodule(name).cloned() {
+                gitmodules_entry.active = Some(false);
+                entries.update_entry(name.to_string(), gitmodules_entry);
+                if let Err(e) = self.git_ops.write_gitmodules(&entries) {
+                    eprintln!("Warning: Failed to update .gitmodules: {e}");
+                }
+            }
+        }
+
         self.write_full_config()?;
         println!("Disabled submodule '{name}'.");
         Ok(())

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1504,7 +1504,7 @@ impl GitManager {
 
         // Update .gitmodules
         if let Ok(mut entries) = self.git_ops.read_gitmodules() {
-            if let Some(mut gitmodules_entry) = entries.get_submodule(name).cloned() {
+            if let Some(mut gitmodules_entry) = entries.get(name).cloned() {
                 gitmodules_entry.active = Some(false);
                 entries.update_entry(name.to_string(), gitmodules_entry);
                 if let Err(e) = self.git_ops.write_gitmodules(&entries) {

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1504,11 +1504,23 @@ impl GitManager {
 
         // Update .gitmodules
         if let Ok(mut entries) = self.git_ops.read_gitmodules() {
-            if let Some(mut gitmodules_entry) = entries.get(name).cloned() {
-                gitmodules_entry.active = Some(false);
-                entries.update_entry(name.to_string(), gitmodules_entry);
-                if let Err(e) = self.git_ops.write_gitmodules(&entries) {
-                    eprintln!("Warning: Failed to update .gitmodules: {e}");
+            // Find by name, or fall back to finding by path
+            let gitmodules_name = if entries.get(name).is_some() {
+                Some(name.to_string())
+            } else {
+                entries
+                    .submodule_iter()
+                    .find(|(_, e)| e.path.as_deref() == Some(path.as_str()))
+                    .map(|(n, _)| n.to_string())
+            };
+
+            if let Some(gm_name) = gitmodules_name {
+                if let Some(mut gitmodules_entry) = entries.get(&gm_name).cloned() {
+                    gitmodules_entry.active = Some(false);
+                    entries.update_entry(gm_name, gitmodules_entry);
+                    if let Err(e) = self.git_ops.write_gitmodules(&entries) {
+                        eprintln!("Warning: Failed to update .gitmodules: {e}");
+                    }
                 }
             }
         }

--- a/src/git_ops/git2_ops.rs
+++ b/src/git_ops/git2_ops.rs
@@ -246,6 +246,10 @@ impl GitOperations for Git2Operations {
                             };
                             config.set_str(&format!("submodule.{name}.update"), update_str)?;
                         }
+                        if let Some(active) = entry.active {
+                            let active_str = if active { "true" } else { "false" };
+                            config.set_str(&format!("submodule.{name}.active"), active_str)?;
+                        }
                         // Set URL if different
                         if let Some(url) = &entry.url
                             && submodule.url() != Some(url.as_str()) {

--- a/src/git_ops/gix_ops.rs
+++ b/src/git_ops/gix_ops.rs
@@ -194,6 +194,15 @@ impl GitOperations for GixOperations {
                         value.as_bytes().as_bstr(),
                     )?;
                 }
+                if let Some(active) = entry.active {
+                    let value = if active { "true" } else { "false" };
+                    git_config.set_raw_value_by(
+                        "submodule",
+                        Some(subsection_name),
+                        "active",
+                        value.as_bytes().as_bstr(),
+                    )?;
+                }
             }
 
             // Write to .gitmodules file

--- a/tests/git_ops_tests.rs
+++ b/tests/git_ops_tests.rs
@@ -414,6 +414,44 @@ mod git2_ops_tests {
         let config_content = std::fs::read_to_string(&config_path).expect("read git config");
         assert!(config_content.contains("active = false"), "submodule should be inactive in config");
     }
+
+    #[test]
+    fn test_with_submodule_write_gitmodules_active_none() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let remote = harness.create_test_remote("g2_write_sub_none").expect("remote");
+        let remote_url = format!("file://{}", remote.display());
+
+        harness
+            .run_submod_success(&[
+                "add",
+                &remote_url,
+                "--name",
+                "write-sub-none",
+                "--path",
+                "lib/writesubnone",
+            ])
+            .expect("add submodule");
+
+        let mut ops = Git2Operations::new(Some(&harness.work_dir)).expect("ops");
+        let mut entries = ops.read_gitmodules().expect("read_gitmodules");
+
+        let name = if entries.get("write-sub-none").is_some() {
+            "write-sub-none"
+        } else {
+            "lib/writesubnone"
+        };
+
+        if let Some(mut entry) = entries.get(name).cloned() {
+            entry.active = None;
+            entries.update_entry(name.to_string(), entry);
+        }
+        ops.write_gitmodules(&entries).expect("write_gitmodules active none");
+
+        let config_path = harness.work_dir.join(".git").join("config");
+        let config_content = std::fs::read_to_string(&config_path).expect("read git config");
+        assert!(!config_content.contains("active ="), "submodule active should be untouched");
+    }
 }
 
 // ============================================================
@@ -595,6 +633,23 @@ mod gix_ops_tests {
             content.contains("active = false"),
             ".gitmodules should contain active = false"
         );
+    }
+
+    #[test]
+    fn test_write_gitmodules_active_none() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let mut ops = GixOperations::new(Some(&harness.work_dir)).expect("ops");
+
+        let mut entries = one_entry_entries();
+        if let Some(mut entry) = entries.get("test-lib").cloned() {
+            entry.active = None;
+            entries.update_entry("test-lib".to_string(), entry);
+        }
+
+        ops.write_gitmodules(&entries).expect("write_gitmodules");
+        let content = std::fs::read_to_string(harness.work_dir.join(".gitmodules")).expect("read");
+        assert!(!content.contains("active ="));
     }
 
     #[test]

--- a/tests/git_ops_tests.rs
+++ b/tests/git_ops_tests.rs
@@ -395,9 +395,16 @@ mod git2_ops_tests {
         ops.write_gitmodules(&entries).expect("write_gitmodules");
 
         // Verify that updating `active` sets it in the git configuration
-        if let Some(mut entry) = entries.get("write-sub").cloned() {
+        // In .gitmodules the git2 fallback might name the submodule by its path 'lib/writesub'
+        let name = if entries.get("write-sub").is_some() {
+            "write-sub"
+        } else {
+            "lib/writesub"
+        };
+
+        if let Some(mut entry) = entries.get(name).cloned() {
             entry.active = Some(false);
-            entries.update_entry("write-sub".to_string(), entry);
+            entries.update_entry(name.to_string(), entry);
         }
         ops.write_gitmodules(&entries).expect("write_gitmodules active false");
 

--- a/tests/git_ops_tests.rs
+++ b/tests/git_ops_tests.rs
@@ -390,9 +390,22 @@ mod git2_ops_tests {
             .expect("add submodule");
 
         let mut ops = Git2Operations::new(Some(&harness.work_dir)).expect("ops");
-        let entries = ops.read_gitmodules().expect("read_gitmodules");
+        let mut entries = ops.read_gitmodules().expect("read_gitmodules");
         // write_gitmodules with the same entries should succeed without error
         ops.write_gitmodules(&entries).expect("write_gitmodules");
+
+        // Verify that updating `active` sets it in the git configuration
+        if let Some(mut entry) = entries.get("write-sub").cloned() {
+            entry.active = Some(false);
+            entries.update_entry("write-sub".to_string(), entry);
+        }
+        ops.write_gitmodules(&entries).expect("write_gitmodules active false");
+
+        // Check git2 config manually or via read_gitmodules? Actually read_gitmodules in git2
+        // doesn't read active from .git/config, but wait, it is set in `.git/config`!
+        let config_path = harness.work_dir.join(".git").join("config");
+        let config_content = std::fs::read_to_string(&config_path).expect("read git config");
+        assert!(config_content.contains("active = false"), "submodule should be inactive in config");
     }
 }
 
@@ -551,6 +564,29 @@ mod gix_ops_tests {
         assert!(
             content.contains("lib/test"),
             ".gitmodules should contain the path we wrote"
+        );
+    }
+
+    #[test]
+    fn test_write_gitmodules_active_false() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let mut ops = GixOperations::new(Some(&harness.work_dir)).expect("ops");
+
+        let mut entries = one_entry_entries();
+        if let Some(mut entry) = entries.get("test-lib").cloned() {
+            entry.active = Some(false);
+            entries.update_entry("test-lib".to_string(), entry);
+        }
+
+        ops.write_gitmodules(&entries)
+            .expect("write_gitmodules should succeed");
+
+        let content = std::fs::read_to_string(harness.work_dir.join(".gitmodules"))
+            .expect("read .gitmodules");
+        assert!(
+            content.contains("active = false"),
+            ".gitmodules should contain active = false"
         );
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -557,6 +557,13 @@ active = true
         // Config should show active = false
         let config = harness.read_config().expect("Failed to read config");
         assert!(config.contains("active = false"));
+
+        // .gitmodules should show active = false
+        let gitmodules_path = harness.work_dir.join(".gitmodules");
+        let gitmodules_content = std::fs::read_to_string(&gitmodules_path)
+            .expect("Failed to read .gitmodules");
+        println!("GITMODULES CONTENT:\n{gitmodules_content}");
+        assert!(gitmodules_content.contains("active = false"));
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -567,6 +567,39 @@ active = true
     }
 
     #[test]
+    fn test_disable_command_matching_name() {
+        let harness = TestHarness::new().expect("Failed to create test harness");
+        harness.init_git_repo().expect("Failed to init git repo");
+
+        // Manually create a .gitmodules with a matching name
+        let gitmodules_content = "\
+[submodule \"my-lib\"]
+\tpath = lib/my
+\turl = https://example.com/my-lib.git
+";
+        std::fs::write(harness.work_dir.join(".gitmodules"), gitmodules_content)
+            .expect("Failed to write .gitmodules");
+
+        let config_content = "\
+[my-lib]
+path = \"lib/my\"
+url = \"https://example.com/my-lib.git\"
+active = true
+";
+        harness.create_config(config_content).expect("Failed to create config");
+
+        let stdout = harness
+            .run_submod_success(&["disable", "my-lib"])
+            .expect("Failed to disable submodule");
+
+        assert!(stdout.contains("Disabled submodule 'my-lib'"));
+
+        let gitmodules_updated = std::fs::read_to_string(harness.work_dir.join(".gitmodules"))
+            .expect("Failed to read .gitmodules");
+        assert!(gitmodules_updated.contains("active = false"));
+    }
+
+    #[test]
     fn test_disable_command_preserves_comments() {
         let harness = TestHarness::new().expect("Failed to create test harness");
         harness.init_git_repo().expect("Failed to init git repo");


### PR DESCRIPTION
Implement disabling a submodule by changing `active = false` in config and .gitmodules without deleting files.

---
*PR created automatically by Jules for task [10095517422925815295](https://jules.google.com/task/10095517422925815295) started by @bashandbone*