### PR TITLE
refactor(tests): make sparse checkout unit tests hermetic and complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,7 +2889,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "submod"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1889,10 +1889,10 @@ mod tests {
     use tempfile::tempdir;
 
 
-    // Helper to create a dummy GitManager. We just need it to call check_sparse_checkout_status,
-    // which only uses `self.get_git_directory()`. It doesn't actually need the full config to be valid.
-    // Helper to create a dummy GitManager without needing a tempdir that gets dropped.
-    // It creates it pointing to the provided temp_dir.
+    // Helper to create a `GitManager` for tests that need to call methods such as
+    // `check_sparse_checkout_status`. It writes a minimal config to `config_path`, but
+    // constructing `GitManager` is not fully dummy here: `GitManager::new` currently
+    // depends on successfully opening a repository via `GitOpsManager`.
     fn create_dummy_manager(config_path: std::path::PathBuf) -> GitManager {
         fs::write(&config_path, "[defaults]\n").unwrap();
         GitManager::new(config_path).expect("Failed to create GitManager")
@@ -1913,7 +1913,7 @@ mod tests {
         let expected_paths: Vec<String> = vec!["path/a".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         assert_eq!(status, SparseStatus::NotConfigured);
@@ -1943,12 +1943,41 @@ mod tests {
         ];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         assert_eq!(status, SparseStatus::Correct);
     }
 
+
+    #[test]
+    fn test_sparse_checkout_configured_has_extras() {
+        let temp_dir = tempdir().unwrap();
+        let submodule_path = temp_dir.path();
+
+        let git_dir = submodule_path.join(".git");
+        let info_dir = git_dir.join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+
+        let sparse_checkout_file = info_dir.join("sparse-checkout");
+        let content = format!("{}\npath/a\npath/b\npath/c\n", SPARSE_DENY_ALL);
+        fs::write(&sparse_checkout_file, content).unwrap();
+
+        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+
+        let expected_paths: Vec<String> = vec![
+            "path/a".to_string(),
+            "path/b".to_string(),
+        ];
+
+        let status = manager
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
+            .unwrap();
+
+        // Currently check_sparse_checkout_status only checks that all expected paths are present.
+        // It returns Correct even if there are extra paths configured.
+        assert_eq!(status, SparseStatus::Correct);
+    }
     #[test]
     fn test_sparse_checkout_mismatch() {
         let temp_dir = tempdir().unwrap();
@@ -1972,7 +2001,7 @@ mod tests {
         ];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         match status {

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -1881,3 +1881,106 @@ impl GitManager {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+
+    // Helper to create a dummy GitManager. We just need it to call check_sparse_checkout_status,
+    // which only uses `self.get_git_directory()`. It doesn't actually need the full config to be valid.
+    // Helper to create a dummy GitManager without needing a tempdir that gets dropped.
+    // It creates it pointing to the provided temp_dir.
+    fn create_dummy_manager(config_path: std::path::PathBuf) -> GitManager {
+        fs::write(&config_path, "[defaults]\n").unwrap();
+        GitManager::new(config_path).expect("Failed to create GitManager")
+    }
+
+    #[test]
+    fn test_sparse_checkout_not_configured() {
+        let temp_dir = tempdir().unwrap();
+        let submodule_path = temp_dir.path();
+
+        // Create .git directory but NO sparse-checkout file
+        let git_dir = submodule_path.join(".git");
+        fs::create_dir(&git_dir).unwrap();
+
+        // Create manager
+        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+
+        let expected_paths: Vec<String> = vec!["path/a".to_string()];
+
+        let status = manager
+            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .unwrap();
+
+        assert_eq!(status, SparseStatus::NotConfigured);
+    }
+
+    #[test]
+    fn test_sparse_checkout_correct() {
+        let temp_dir = tempdir().unwrap();
+        let submodule_path = temp_dir.path();
+
+        // Create .git/info/sparse-checkout file
+        let git_dir = submodule_path.join(".git");
+        let info_dir = git_dir.join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+
+        let sparse_checkout_file = info_dir.join("sparse-checkout");
+        // Prepend SPARSE_DENY_ALL as handled in check_sparse_checkout_status
+        let content = format!("{}\npath/a\npath/b\n", SPARSE_DENY_ALL);
+        fs::write(&sparse_checkout_file, content).unwrap();
+
+        // Create manager
+        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+
+        let expected_paths: Vec<String> = vec![
+            "path/a".to_string(),
+            "path/b".to_string(),
+        ];
+
+        let status = manager
+            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .unwrap();
+
+        assert_eq!(status, SparseStatus::Correct);
+    }
+
+    #[test]
+    fn test_sparse_checkout_mismatch() {
+        let temp_dir = tempdir().unwrap();
+        let submodule_path = temp_dir.path();
+
+        // Create .git/info/sparse-checkout file
+        let git_dir = submodule_path.join(".git");
+        let info_dir = git_dir.join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+
+        let sparse_checkout_file = info_dir.join("sparse-checkout");
+        let content = format!("{}\npath/a\n", SPARSE_DENY_ALL);
+        fs::write(&sparse_checkout_file, content).unwrap();
+
+        // Create manager
+        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+
+        let expected_paths: Vec<String> = vec![
+            "path/a".to_string(),
+            "path/b".to_string(), // This is expected but not configured
+        ];
+
+        let status = manager
+            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .unwrap();
+
+        match status {
+            SparseStatus::Mismatch { expected, actual } => {
+                assert_eq!(expected, vec!["path/a".to_string(), "path/b".to_string()]);
+                assert_eq!(actual, vec!["path/a".to_string()]);
+            }
+            _ => panic!("Expected Mismatch, got {:?}", status),
+        }
+    }
+}

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -344,6 +344,27 @@ impl GitManager {
         })
     }
 
+    /// Creates a `GitManager` pointed at an explicit repository path.
+    ///
+    /// Used in tests to avoid depending on the caller's working directory
+    /// being a git repository.
+    #[cfg(test)]
+    fn with_repo_path(config_path: PathBuf, repo_path: &Path) -> Result<Self, SubmoduleError> {
+        let git_ops = GitOpsManager::new(Some(repo_path), false)
+            .map_err(|_| SubmoduleError::RepositoryError)?;
+
+        let config = Config::default()
+            .load(&config_path, Config::default())
+            .map_err(|e| SubmoduleError::ConfigError(format!("Failed to load config: {e}")))?;
+
+        Ok(Self {
+            git_ops,
+            config,
+            config_path,
+            verbose: false,
+        })
+    }
+
     /// Check submodule repository status using gix APIs
     pub fn check_submodule_repository_status(
         &self,
@@ -406,7 +427,14 @@ impl GitManager {
         })
     }
 
-    /// Check sparse checkout configuration
+    /// Check whether the sparse-checkout configuration for a submodule matches
+    /// the expected paths.
+    ///
+    /// Returns [`SparseStatus::Correct`] when every expected path is present in
+    /// the configured file.  Extra patterns in the file that are not in
+    /// `expected_paths` are **not** treated as a mismatch; the check is a
+    /// subset test (all expected ⊆ configured).  Returns [`SparseStatus::Mismatch`]
+    /// when at least one expected path is absent from the file.
     pub fn check_sparse_checkout_status(
         &self,
         submodule_path: &str,
@@ -1888,32 +1916,35 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-
-    // Helper to create a dummy GitManager. We just need it to call check_sparse_checkout_status,
-    // which only uses `self.get_git_directory()`. It doesn't actually need the full config to be valid.
-    // Helper to create a dummy GitManager without needing a tempdir that gets dropped.
-    // It creates it pointing to the provided temp_dir.
-    fn create_dummy_manager(config_path: std::path::PathBuf) -> GitManager {
+    // Helper to create a `GitManager` for tests that need to call methods such as
+    // `check_sparse_checkout_status`. It initialises a real git repository in `repo_dir`
+    // via `git2` so that `GitOpsManager` can open it without depending on the caller's
+    // working directory being inside a git repo.
+    fn create_test_manager(repo_dir: &Path, config_path: PathBuf) -> GitManager {
+        git2::Repository::init(repo_dir).expect("Failed to init git repo");
         fs::write(&config_path, "[defaults]\n").unwrap();
-        GitManager::new(config_path).expect("Failed to create GitManager")
+        GitManager::with_repo_path(config_path, repo_dir).expect("Failed to create GitManager")
     }
 
     #[test]
     fn test_sparse_checkout_not_configured() {
         let temp_dir = tempdir().unwrap();
-        let submodule_path = temp_dir.path();
+        let submodule_path = temp_dir.path().join("submodule");
+        fs::create_dir(&submodule_path).unwrap();
 
         // Create .git directory but NO sparse-checkout file
         let git_dir = submodule_path.join(".git");
         fs::create_dir(&git_dir).unwrap();
 
-        // Create manager
-        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+        let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
 
         let expected_paths: Vec<String> = vec!["path/a".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(
+                &submodule_path.to_string_lossy(),
+                &expected_paths,
+            )
             .unwrap();
 
         assert_eq!(status, SparseStatus::NotConfigured);
@@ -1922,28 +1953,52 @@ mod tests {
     #[test]
     fn test_sparse_checkout_correct() {
         let temp_dir = tempdir().unwrap();
-        let submodule_path = temp_dir.path();
+        let submodule_path = temp_dir.path().join("submodule");
+        fs::create_dir(&submodule_path).unwrap();
 
-        // Create .git/info/sparse-checkout file
-        let git_dir = submodule_path.join(".git");
-        let info_dir = git_dir.join("info");
+        // Create .git/info/sparse-checkout with the expected paths
+        let info_dir = submodule_path.join(".git").join("info");
         fs::create_dir_all(&info_dir).unwrap();
-
-        let sparse_checkout_file = info_dir.join("sparse-checkout");
-        // Prepend SPARSE_DENY_ALL as handled in check_sparse_checkout_status
         let content = format!("{}\npath/a\npath/b\n", SPARSE_DENY_ALL);
-        fs::write(&sparse_checkout_file, content).unwrap();
+        fs::write(info_dir.join("sparse-checkout"), content).unwrap();
 
-        // Create manager
-        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+        let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
 
-        let expected_paths: Vec<String> = vec![
-            "path/a".to_string(),
-            "path/b".to_string(),
-        ];
+        let expected_paths = vec!["path/a".to_string(), "path/b".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(
+                &submodule_path.to_string_lossy(),
+                &expected_paths,
+            )
+            .unwrap();
+
+        assert_eq!(status, SparseStatus::Correct);
+    }
+
+    #[test]
+    fn test_sparse_checkout_correct_with_extras() {
+        // When the sparse-checkout file contains all expected paths plus additional
+        // ones, the result is still Correct (subset check, not equality).
+        let temp_dir = tempdir().unwrap();
+        let submodule_path = temp_dir.path().join("submodule");
+        fs::create_dir(&submodule_path).unwrap();
+
+        let info_dir = submodule_path.join(".git").join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+        // File has path/a, path/b AND an extra path/c not in expected_paths
+        let content = format!("{}\npath/a\npath/b\npath/c\n", SPARSE_DENY_ALL);
+        fs::write(info_dir.join("sparse-checkout"), content).unwrap();
+
+        let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
+
+        let expected_paths = vec!["path/a".to_string(), "path/b".to_string()];
+
+        let status = manager
+            .check_sparse_checkout_status(
+                &submodule_path.to_string_lossy(),
+                &expected_paths,
+            )
             .unwrap();
 
         assert_eq!(status, SparseStatus::Correct);
@@ -1952,27 +2007,27 @@ mod tests {
     #[test]
     fn test_sparse_checkout_mismatch() {
         let temp_dir = tempdir().unwrap();
-        let submodule_path = temp_dir.path();
+        let submodule_path = temp_dir.path().join("submodule");
+        fs::create_dir(&submodule_path).unwrap();
 
-        // Create .git/info/sparse-checkout file
-        let git_dir = submodule_path.join(".git");
-        let info_dir = git_dir.join("info");
+        // sparse-checkout has only path/a; path/b is expected but absent
+        let info_dir = submodule_path.join(".git").join("info");
         fs::create_dir_all(&info_dir).unwrap();
-
-        let sparse_checkout_file = info_dir.join("sparse-checkout");
         let content = format!("{}\npath/a\n", SPARSE_DENY_ALL);
-        fs::write(&sparse_checkout_file, content).unwrap();
+        fs::write(info_dir.join("sparse-checkout"), content).unwrap();
 
-        // Create manager
-        let manager = create_dummy_manager(temp_dir.path().join("submod.toml"));
+        let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
 
-        let expected_paths: Vec<String> = vec![
+        let expected_paths = vec![
             "path/a".to_string(),
-            "path/b".to_string(), // This is expected but not configured
+            "path/b".to_string(), // expected but not configured
         ];
 
         let status = manager
-            .check_sparse_checkout_status(submodule_path.to_str().unwrap(), &expected_paths)
+            .check_sparse_checkout_status(
+                &submodule_path.to_string_lossy(),
+                &expected_paths,
+            )
             .unwrap();
 
         match status {


### PR DESCRIPTION
Unit tests for `GitManager::check_sparse_checkout_status` depended on the caller's CWD being a git repo, had a duplicated/contradictory helper comment, used `to_str().unwrap()` on temp paths, and were missing a test for the "configured has extras" case.

## Changes

- **Hermetic test constructor**: Added `GitManager::with_repo_path` (`#[cfg(test)]`) that accepts an explicit `&Path` and initialises a real `git2::Repository` there — eliminates the implicit CWD dependency in `GitManager::new`

```rust
#[cfg(test)]
fn with_repo_path(config_path: PathBuf, repo_path: &Path) -> Result<Self, SubmoduleError> {
    let git_ops = GitOpsManager::new(Some(repo_path), false)
        .map_err(|_| SubmoduleError::RepositoryError)?;
    ...
}
```

- **Test helper**: Replaced `create_dummy_manager` (non-hermetic, misleading comment) with `create_test_manager(repo_dir, config_path)` that calls `git2::Repository::init` before constructing the manager

- **`to_string_lossy()`**: Replaced all `to_str().unwrap()` calls on temp paths

- **Superset/extras test**: Added `test_sparse_checkout_correct_with_extras` to pin the subset-check semantics — configured paths ⊇ expected → `Correct`; updated `check_sparse_checkout_status` doc to state this explicitly