### PR TITLE
⚡ Optimize submodule lookup by avoiding redundant string clones

### DIFF
--- a/src/git_ops/git2_ops.rs
+++ b/src/git_ops/git2_ops.rs
@@ -215,13 +215,7 @@ impl GitOperations for Git2Operations {
         if let Some(submodules) = config.submodules().as_ref() {
             for (name, entry) in submodules.iter() {
                 // Find or create the submodule
-                match self.repo.find_submodule(
-                    &entry
-                        .path
-                        .as_ref()
-                        .map(|p| p.to_string())
-                        .unwrap_or(name.clone()),
-                ) {
+                match self.repo.find_submodule(entry.path.as_deref().unwrap_or(name)) {
                     Ok(mut submodule) => {
                         // Update existing submodule configuration through git config
                         let mut config = self.repo.config()?;


### PR DESCRIPTION
💡 **What:** The optimization replaces `entry.path.as_ref().map(|p| p.to_string()).unwrap_or(name.clone())` with `entry.path.as_deref().unwrap_or(name)` in `src/git_ops/git2_ops.rs`.

🎯 **Why:** The previous implementation forced heap allocations in two ways:
1. `map(|p| p.to_string())` allocated a new string for `path` even though `find_submodule` only needs a `&str`.
2. `unwrap_or(name.clone())` eagerly cloned the `name` string on every iteration, even when `path` was `Some`.

📊 **Measured Improvement:** I was unable to show a meaningful performance improvement using the provided `cargo bench` or `cargo test` because the environment lacked necessary dependencies (like `bitflags`) and had no network access to fetch them. However, the theoretical benefit is clear: it avoids at least one `String` allocation per submodule during the `.gitmodules` write operation, which is a significant reduction in overhead for repositories with many submodules. I verified the logical equivalence of the change using a standalone `rustc` script.

---
*PR created automatically by Jules for task [8596418518332672665](https://jules.google.com/task/8596418518332672665) started by @bashandbone*