### PR TITLE
🧹 replace unwrap with proper error handling in config parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -739,22 +739,10 @@ impl SubmoduleEntries {
     }
 
     /// Add a submodule entry
-    #[must_use] pub fn add_submodule(self, name: SubmoduleName, entry: SubmoduleEntry) -> Self {
-        if self.submodules().is_some() {
-            let mut submodules = self.submodules.unwrap();
-            submodules.insert(name, entry);
-            Self {
-                submodules: Some(submodules),
-                sparse_checkouts: self.sparse_checkouts,
-            }
-        } else {
-            let mut submodules = HashMap::new();
-            submodules.insert(name, entry);
-            Self {
-                submodules: Some(submodules),
-                sparse_checkouts: self.sparse_checkouts,
-            }
-        }
+    #[must_use] pub fn add_submodule(mut self, name: SubmoduleName, entry: SubmoduleEntry) -> Self {
+        let submodules = self.submodules.get_or_insert_with(HashMap::new);
+        submodules.insert(name, entry);
+        self
     }
 
     /// Remove a submodule entry


### PR DESCRIPTION
This PR addresses a code health issue in `src/config.rs` where an `unwrap()` was used in `SubmoduleEntries::add_submodule`.

🎯 **What:** Replaced the `if ... is_some() { let mut s = self.submodules.unwrap(); ... }` pattern with `self.submodules.get_or_insert_with(HashMap::new)`.

💡 **Why:** This makes the code more concise, idiomatic, and safer by avoiding explicit `unwrap()`, even when technically guarded.

✅ **Verification:** 
- Manual inspection of the refactored code.
- Verification of the logic using a standalone Rust script (since the offline environment prevented running the full `cargo` test suite). The script confirmed that both `None` and `Some` cases are handled correctly.

✨ **Result:** Improved maintainability and readability of the configuration management logic.

---
*PR created automatically by Jules for task [6923600226195808177](https://jules.google.com/task/6923600226195808177) started by @bashandbone*