### PR TITLE
fix(config): round-trip the fetchRecurse config key correctly

### DIFF
--- a/sample_config/submod.toml
+++ b/sample_config/submod.toml
@@ -13,7 +13,7 @@ schema_version = "1.1.0"
 # [defaults]
 # ignore = "none"
 # update = "checkout"
-# fetch = "on-demand"
+# fetchRecurse = "on-demand"
 # ```
 # Submodule paths can't be set globally, but their default assignment is the submodule name in the repository root.
 #
@@ -21,7 +21,7 @@ schema_version = "1.1.0"
 # See [docs](https://docs.rs/submod/latest/submod/options/) for details.
 # - `ignore`: "all", "dirty", "untracked", "none" [default]
 # - `update`: "checkout" [default], "rebase", "merge", "none"
-# - `fetch`: "on-demand" [default], "always", "never"
+# - `fetchRecurse`: "on-demand" [default], "always", "never"
 
 [defaults]
 ignore = "dirty" # Override default ignore setting for all submodules
@@ -35,7 +35,7 @@ ignore = "dirty" # Override default ignore setting for all submodules
 #
 # ## Available Options
 #
-# **Submodules support all global options (ignore, fetch, update)**, which will override the defaults. If you want a submodule to maintain default behavior, but set a different global behavior, you *must* explicitly add the options here. Other submodule options are:
+# **Submodules support all global options (ignore, fetchRecurse, update)**, which will override the defaults. If you want a submodule to maintain default behavior, but set a different global behavior, you *must* explicitly add the options here. Other submodule options are:
 #
 # ## `url`
 # **Required.** The submodule repository URL. Use the same value as in `.gitmodules` or `.git/config`. Accepts remote URLs or local paths (absolute or relative).

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,7 +67,10 @@ pub struct SubmoduleGitOptions {
     #[serde(default)]
     pub ignore: Option<SerializableIgnore>,
     /// Whether to fetch submodules recursively
-    #[serde(default)]
+    // Serialized as the documented `fetchRecurse` TOML key (see README). The rename keeps
+    // the serialized and deserialized spellings identical so figment's layered merge does
+    // not see two different keys for the same field.
+    #[serde(default, rename = "fetchRecurse")]
     pub fetch_recurse: Option<SerializableFetchRecurse>,
     /// Branch to track for the submodule
     #[serde(default)]
@@ -80,7 +83,8 @@ pub struct SubmoduleGitOptions {
 #[allow(dead_code)]
 impl SubmoduleGitOptions {
     /// Create a new instance with defaults
-    #[must_use] pub const fn new(
+    #[must_use]
+    pub const fn new(
         ignore: Option<SerializableIgnore>,
         fetch_recurse: Option<SerializableFetchRecurse>,
         branch: Option<SerializableBranch>,
@@ -95,7 +99,8 @@ impl SubmoduleGitOptions {
     }
 
     /// new with defaults
-    #[must_use] pub fn default() -> Self {
+    #[must_use]
+    pub fn default() -> Self {
         Self {
             ignore: Some(SerializableIgnore::default()),
             fetch_recurse: Some(SerializableFetchRecurse::default()),
@@ -118,7 +123,8 @@ pub struct Git2SubmoduleOptions {
 #[allow(dead_code)]
 impl Git2SubmoduleOptions {
     /// Create a new `Git2SubmoduleOptions` from individual git2 option values.
-    #[must_use] pub const fn new(
+    #[must_use]
+    pub const fn new(
         ignore: git2::SubmoduleIgnore,
         update: git2::SubmoduleUpdate,
         branch: Option<String>,
@@ -163,6 +169,7 @@ pub struct SubmoduleDefaults {
     /// [`Ignore`][SerializableIgnore] setting for submodules
     pub ignore: Option<SerializableIgnore>,
     /// [`Update`][SerializableUpdate] setting for submodules
+    #[serde(rename = "fetchRecurse")]
     pub fetch_recurse: Option<SerializableFetchRecurse>,
     /// [`Update`][SerializableUpdate] setting for submodules
     pub update: Option<SerializableUpdate>,
@@ -184,12 +191,14 @@ impl Iterator for SubmoduleDefaults {
 #[allow(dead_code)]
 impl SubmoduleDefaults {
     /// Returns a vector of `SubmoduleDefaults` with the current values (for comparison)
-    #[must_use] pub fn get_values(&self) -> Vec<Self> {
+    #[must_use]
+    pub fn get_values(&self) -> Vec<Self> {
         vec![self.clone()].into_iter().flatten().collect()
     }
 
     /// Merge another `SubmoduleDefaults` into this one. Only updates fields that are set in the other. Returns a new instance with the merged values.
-    #[must_use] pub fn merge_from(&self, other: Self) -> Self {
+    #[must_use]
+    pub fn merge_from(&self, other: Self) -> Self {
         let mut mut_self = self.clone();
         if other.ignore.is_some() {
             mut_self.ignore = other.ignore;
@@ -242,7 +251,8 @@ pub struct SubmoduleAddOptions {
 #[allow(dead_code)]
 impl SubmoduleAddOptions {
     /// Create an add options from a `SubmoduleEntry`
-    #[must_use] pub fn into_submodule_entry(self) -> SubmoduleEntry {
+    #[must_use]
+    pub fn into_submodule_entry(self) -> SubmoduleEntry {
         SubmoduleEntry {
             url: Some(self.url),
             path: Some(self.path.to_string_lossy().to_string()),
@@ -267,7 +277,8 @@ impl SubmoduleAddOptions {
                 .url
                 .unwrap_or_else(|| submodule_entry.path.clone().unwrap_or_else(|| name.clone())),
             path: submodule_entry
-                .path.map_or_else(|| PathBuf::from(name.clone()), PathBuf::from),
+                .path
+                .map_or_else(|| PathBuf::from(name.clone()), PathBuf::from),
             branch: submodule_entry.branch,
             ignore: submodule_entry.ignore,
             update: submodule_entry.update,
@@ -278,7 +289,8 @@ impl SubmoduleAddOptions {
     }
 
     /// Convert an `AddOptions` to a `SubmoduleEntries` tuple
-    #[must_use] pub fn into_entries_tuple(self) -> (SubmoduleName, SubmoduleEntry) {
+    #[must_use]
+    pub fn into_entries_tuple(self) -> (SubmoduleName, SubmoduleEntry) {
         (self.name.clone(), self.into_submodule_entry())
     }
 }
@@ -297,7 +309,8 @@ pub struct SubmoduleUpdateOptions {
 #[allow(dead_code)]
 impl SubmoduleUpdateOptions {
     /// Create a new instance with defaults
-    #[must_use] pub const fn new(strategy: SerializableUpdate, recursive: bool, force: bool) -> Self {
+    #[must_use]
+    pub const fn new(strategy: SerializableUpdate, recursive: bool, force: bool) -> Self {
         Self {
             strategy,
             recursive,
@@ -306,7 +319,8 @@ impl SubmoduleUpdateOptions {
     }
 
     /// Create a new instance with default values
-    #[must_use] pub fn default() -> Self {
+    #[must_use]
+    pub fn default() -> Self {
         Self {
             strategy: SerializableUpdate::default(),
             recursive: false, // Default to not recursive
@@ -315,7 +329,8 @@ impl SubmoduleUpdateOptions {
     }
 
     /// Get a new instance with the recursive flag set
-    #[must_use] pub fn forced(&self) -> Self {
+    #[must_use]
+    pub fn forced(&self) -> Self {
         Self {
             strategy: self.strategy.clone(),
             recursive: self.recursive,
@@ -324,7 +339,8 @@ impl SubmoduleUpdateOptions {
     }
 
     /// Convert from `SubmoduleGitOptions` to `SubmoduleUpdateOptions`
-    #[must_use] pub fn from_options(options: SubmoduleGitOptions) -> Self {
+    #[must_use]
+    pub fn from_options(options: SubmoduleGitOptions) -> Self {
         Self {
             strategy: options.update.unwrap_or_default(),
             recursive: match options.fetch_recurse {
@@ -386,13 +402,15 @@ impl OtherSubmoduleSettings {
     ) -> Self {
         Self {
             url: url.clone().or_else(|| Some(".".to_string())),
-            path: path.clone().or_else(|| {
-                url.as_ref().map(|u| Self::name_from_url(u))
-            }),
+            path: path
+                .clone()
+                .or_else(|| url.as_ref().map(|u| Self::name_from_url(u))),
             name: name.or_else(|| {
                 if let Some(ref p) = path {
                     Some(p.clone())
-                } else { url.as_ref().map(|u| Self::name_from_url(u)) }
+                } else {
+                    url.as_ref().map(|u| Self::name_from_url(u))
+                }
             }),
             active: active.unwrap_or(true), // Default to true if not specified
             shallow: shallow.unwrap_or(false), // Default to false if not specified
@@ -407,7 +425,8 @@ impl OtherSubmoduleSettings {
     }
 
     /// Create a new instance from `SubmoduleEntry`, optionally providing a name
-    #[must_use] pub fn from_entry(entry: &SubmoduleEntry, name: Option<String>) -> Self {
+    #[must_use]
+    pub fn from_entry(entry: &SubmoduleEntry, name: Option<String>) -> Self {
         Self::new(
             entry.url.clone(),
             entry.path.clone(),
@@ -419,7 +438,8 @@ impl OtherSubmoduleSettings {
     }
 
     /// Get a new instance with an updated name
-    #[must_use] pub fn update_with_name(&self, name: SubmoduleName) -> Self {
+    #[must_use]
+    pub fn update_with_name(&self, name: SubmoduleName) -> Self {
         let mut new_self = self.clone();
         new_self.name = Some(name);
         new_self
@@ -445,6 +465,7 @@ pub struct SubmoduleEntry {
     /// Update strategy (optional)
     pub update: Option<SerializableUpdate>,
     /// Fetch recurse setting (optional)
+    #[serde(rename = "fetchRecurse")]
     pub fetch_recurse: Option<SerializableFetchRecurse>,
     /// Whether the submodule is active
     pub active: Option<bool>,
@@ -465,7 +486,8 @@ pub struct SubmoduleEntry {
 #[allow(dead_code)]
 impl SubmoduleEntry {
     /// Create a new submodule entry with defaults
-    #[must_use] pub const fn new(
+    #[must_use]
+    pub const fn new(
         url: Option<String>,
         path: Option<String>,
         branch: Option<SerializableBranch>,
@@ -492,7 +514,8 @@ impl SubmoduleEntry {
     }
 
     /// Create a new submodule entry with defaults, using the URL and path from `OtherSubmoduleSettings`
-    #[must_use] pub fn from_options_and_settings(
+    #[must_use]
+    pub fn from_options_and_settings(
         options: SubmoduleGitOptions,
         other_settings: OtherSubmoduleSettings,
     ) -> Self {
@@ -510,7 +533,8 @@ impl SubmoduleEntry {
     }
 
     /// Create a new submodule entries from a gitmodules entry
-    #[must_use] pub fn from_gitmodules(
+    #[must_use]
+    pub fn from_gitmodules(
         name: &String,
         entries: std::collections::HashMap<String, String>,
     ) -> Self {
@@ -556,7 +580,8 @@ impl SubmoduleEntry {
     }
 
     /// Get a new instance with updated options
-    #[must_use] pub fn update_with_options(&self, options: SubmoduleGitOptions) -> Self {
+    #[must_use]
+    pub fn update_with_options(&self, options: SubmoduleGitOptions) -> Self {
         let mut new_self = self.clone();
         if let Some(ignore) = options.ignore {
             new_self.ignore = Some(ignore);
@@ -574,7 +599,8 @@ impl SubmoduleEntry {
     }
 
     /// Get a new instance with updated settings
-    #[must_use] pub fn update_with_settings(&self, other_settings: OtherSubmoduleSettings) -> Self {
+    #[must_use]
+    pub fn update_with_settings(&self, other_settings: OtherSubmoduleSettings) -> Self {
         let mut new_self = self.clone();
         if let Some(url) = other_settings.url {
             new_self.url = Some(url);
@@ -589,13 +615,15 @@ impl SubmoduleEntry {
     }
 
     /// Returns true if the url is a local path (relative or absolute)
-    #[must_use] pub fn is_local(&self) -> bool {
+    #[must_use]
+    pub fn is_local(&self) -> bool {
         let url = self.url.clone().unwrap_or_default();
         url.starts_with("./") || url.starts_with("../") || url.starts_with('/')
     }
 
     /// Returns true if the url is a remote repository (http, ssh, git, etc)
-    #[must_use] pub fn is_remote(&self) -> bool {
+    #[must_use]
+    pub fn is_remote(&self) -> bool {
         let url = self.url.clone().unwrap_or_default();
         url.starts_with("http://")
             || url.starts_with("https://")
@@ -611,7 +639,8 @@ impl SubmoduleEntry {
     }
 
     /// Returns the git-specific options for this submodule entry.
-    #[must_use] pub fn git_options(&self) -> SubmoduleGitOptions {
+    #[must_use]
+    pub fn git_options(&self) -> SubmoduleGitOptions {
         SubmoduleGitOptions {
             ignore: self.ignore,
             fetch_recurse: self.fetch_recurse,
@@ -621,7 +650,8 @@ impl SubmoduleEntry {
     }
 
     /// Returns the non-git settings for this submodule entry (path, url, active state, etc.).
-    #[must_use] pub fn settings(&self) -> OtherSubmoduleSettings {
+    #[must_use]
+    pub fn settings(&self) -> OtherSubmoduleSettings {
         OtherSubmoduleSettings {
             name: None, // We don't have a name in this struct, so we leave it as None
             url: self.url.clone(),
@@ -643,12 +673,14 @@ impl SubmoduleEntry {
     }
 
     /// Convert the submodule's URL to a string
-    #[must_use] pub fn url_as_string(&self) -> String {
+    #[must_use]
+    pub fn url_as_string(&self) -> String {
         self.url.clone().unwrap_or_default()
     }
 
     /// Get the configuration active setting
-    #[must_use] pub fn is_active(&self) -> bool {
+    #[must_use]
+    pub fn is_active(&self) -> bool {
         self.active.unwrap_or(true)
     }
 }
@@ -690,9 +722,10 @@ impl<'de> Deserialize<'de> for SubmoduleEntries {
         let mut sparse_checkouts: HashMap<SubmoduleName, Vec<String>> = HashMap::new();
         for (name, entry) in &map {
             if let Some(paths) = &entry.sparse_paths
-                && !paths.is_empty() {
-                    sparse_checkouts.insert(name.clone(), paths.clone());
-                }
+                && !paths.is_empty()
+            {
+                sparse_checkouts.insert(name.clone(), paths.clone());
+            }
         }
         Ok(Self {
             submodules: Some(map),
@@ -720,7 +753,8 @@ impl Serialize for SubmoduleEntries {
 #[allow(dead_code)]
 impl SubmoduleEntries {
     /// Create a new empty `SubmoduleEntries`
-    #[must_use] pub fn new(
+    #[must_use]
+    pub fn new(
         submodules: Option<HashMap<SubmoduleName, SubmoduleEntry>>,
         sparse_checkouts: Option<HashMap<SubmoduleName, Vec<String>>>,
     ) -> Self {
@@ -731,7 +765,8 @@ impl SubmoduleEntries {
     }
 
     /// Create a new empty `SubmoduleEntries` with default (empty) collections.
-    #[must_use] pub fn default() -> Self {
+    #[must_use]
+    pub fn default() -> Self {
         Self {
             submodules: Some(HashMap::new()),
             sparse_checkouts: Some(HashMap::new()),
@@ -739,7 +774,8 @@ impl SubmoduleEntries {
     }
 
     /// Add a submodule entry
-    #[must_use] pub fn add_submodule(mut self, name: SubmoduleName, entry: SubmoduleEntry) -> Self {
+    #[must_use]
+    pub fn add_submodule(mut self, name: SubmoduleName, entry: SubmoduleEntry) -> Self {
         let submodules = self.submodules.get_or_insert_with(HashMap::new);
         submodules.insert(name, entry);
         self
@@ -754,19 +790,22 @@ impl SubmoduleEntries {
     }
 
     /// Returns a list of all submodule names, or `None` if no submodules are configured.
-    #[must_use] pub fn submodule_names(&self) -> Option<Vec<String>> {
+    #[must_use]
+    pub fn submodule_names(&self) -> Option<Vec<String>> {
         self.submodules
             .as_ref()
             .map(|s| s.keys().cloned().collect())
     }
 
     /// Get the submodules map
-    #[must_use] pub const fn submodules(&self) -> Option<&HashMap<SubmoduleName, SubmoduleEntry>> {
+    #[must_use]
+    pub const fn submodules(&self) -> Option<&HashMap<SubmoduleName, SubmoduleEntry>> {
         self.submodules.as_ref()
     }
 
     /// Get the sparse checkouts map
-    #[must_use] pub const fn sparse_checkouts(&self) -> Option<&HashMap<SubmoduleName, Vec<String>>> {
+    #[must_use]
+    pub const fn sparse_checkouts(&self) -> Option<&HashMap<SubmoduleName, Vec<String>>> {
         self.sparse_checkouts.as_ref()
     }
 
@@ -802,12 +841,13 @@ impl SubmoduleEntries {
     /// Remove a sparse checkout path
     pub fn remove_sparse_path(&mut self, name: SubmoduleName, path: String) {
         if let Some(sparse_checkouts) = &mut self.sparse_checkouts
-            && let Some(paths) = sparse_checkouts.get_mut(&name) {
-                paths.retain(|p| p != &path);
-                if paths.is_empty() {
-                    sparse_checkouts.remove(&name); // Remove the entry if no paths left
-                }
+            && let Some(paths) = sparse_checkouts.get_mut(&name)
+        {
+            paths.retain(|p| p != &path);
+            if paths.is_empty() {
+                sparse_checkouts.remove(&name); // Remove the entry if no paths left
             }
+        }
     }
 
     /// Add a sparse path
@@ -820,12 +860,14 @@ impl SubmoduleEntries {
     }
 
     /// Get a submodule entry by name
-    #[must_use] pub fn get(&self, name: &str) -> Option<&SubmoduleEntry> {
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&SubmoduleEntry> {
         self.submodules.as_ref()?.get(name)
     }
 
     /// Returns `true` if a submodule with the given name exists.
-    #[must_use] pub fn contains_key(&self, name: &str) -> bool {
+    #[must_use]
+    pub fn contains_key(&self, name: &str) -> bool {
         self.submodules
             .as_ref()
             .is_some_and(|s| s.contains_key(name))
@@ -858,7 +900,8 @@ impl SubmoduleEntries {
     }
 
     /// Create a new `SubmoduleEntries` from a `HashMap` of submodule entries
-    #[must_use] pub fn from_gitmodules(
+    #[must_use]
+    pub fn from_gitmodules(
         entries: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
     ) -> Self {
         let mut submodules = HashMap::new();
@@ -933,7 +976,8 @@ pub struct Config {
 #[allow(dead_code)]
 impl Config {
     /// Create a new configuration with the given defaults and submodules
-    #[must_use] pub const fn new(defaults: SubmoduleDefaults, submodules: SubmoduleEntries) -> Self {
+    #[must_use]
+    pub const fn new(defaults: SubmoduleDefaults, submodules: SubmoduleEntries) -> Self {
         Self {
             defaults,
             submodules,
@@ -941,7 +985,8 @@ impl Config {
     }
 
     /// Create a new empty configuration with default values
-    #[must_use] pub fn default() -> Self {
+    #[must_use]
+    pub fn default() -> Self {
         Self {
             defaults: SubmoduleDefaults::default(),
             submodules: SubmoduleEntries::default(),
@@ -965,7 +1010,8 @@ impl Config {
     }
 
     /// Create a new configuration, resolving defaults
-    #[must_use] pub fn apply_defaults(mut self) -> Self {
+    #[must_use]
+    pub fn apply_defaults(mut self) -> Self {
         if let Some(submodules) = self.submodules.submodules.as_mut() {
             for sub in submodules.values_mut() {
                 Self::apply_option_default(
@@ -1013,7 +1059,8 @@ impl Config {
 
     /// Get a submodule configuration by name
     /// Returns None if the submodule does not exist
-    #[must_use] pub fn get_submodule(&self, name: &str) -> Option<&SubmoduleEntry> {
+    #[must_use]
+    pub fn get_submodule(&self, name: &str) -> Option<&SubmoduleEntry> {
         self.submodules.get(name)
     }
 
@@ -2089,6 +2136,35 @@ active = true
         assert_eq!(opts.fetch_recurse, Some(SerializableFetchRecurse::Always));
     }
 
+    #[test]
+    fn test_config_toml_fetch_recurse_camelcase_key_is_parsed() {
+        // README documents the key as `fetchRecurse` (camelCase). It must
+        // deserialize into the `fetch_recurse` field rather than being
+        // silently dropped. Assert the PARSED value, not the file text.
+        let toml_str = r#"
+[defaults]
+fetchRecurse = "always"
+
+[mymod]
+path = "libs/mymod"
+url = "https://example.com/repo.git"
+fetchRecurse = "never"
+active = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.defaults.fetch_recurse,
+            Some(SerializableFetchRecurse::Always),
+            "[defaults] fetchRecurse should parse into fetch_recurse"
+        );
+        let entry = config.submodules.get("mymod").unwrap();
+        assert_eq!(
+            entry.fetch_recurse,
+            Some(SerializableFetchRecurse::Never),
+            "per-submodule fetchRecurse should parse into fetch_recurse"
+        );
+    }
+
     // ================================================================
     // SubmoduleEntries::from_gitmodules
     // ================================================================
@@ -2172,7 +2248,9 @@ active = true
         );
         config.add_submodule("repo".to_string(), entry.clone());
 
-        let retrieved = config.get_submodule("repo").expect("submodule should exist");
+        let retrieved = config
+            .get_submodule("repo")
+            .expect("submodule should exist");
         assert_eq!(retrieved, &entry);
 
         assert!(config.get_submodule("non-existent").is_none());

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -272,9 +272,9 @@ impl GitManager {
                     }
                 }
                 if let Some(fetch_recurse) = &entry.fetch_recurse {
-                    let val = fetch_recurse.to_string();
+                    let val = fetch_recurse.as_config_value();
                     if !val.is_empty() {
-                        output.push_str(&format!("fetch = \"{val}\"\n"));
+                        output.push_str(&format!("fetchRecurse = \"{val}\"\n"));
                     }
                 }
                 if let Some(update) = &entry.update {
@@ -287,20 +287,20 @@ impl GitManager {
                     output.push_str(&format!("active = {active}\n"));
                 }
                 if let Some(shallow) = entry.shallow
-                    && shallow {
-                        output.push_str("shallow = true\n");
-                    }
+                    && shallow
+                {
+                    output.push_str("shallow = true\n");
+                }
                 if let Some(sparse_paths) = &entry.sparse_paths
-                    && !sparse_paths.is_empty() {
-                        let joined = sparse_paths
-                            .iter()
-                            .map(|p| {
-                                format!("\"{}\"", p.replace('\\', "\\\\").replace('"', "\\\""))
-                            })
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        output.push_str(&format!("sparse_paths = [{joined}]\n"));
-                    }
+                    && !sparse_paths.is_empty()
+                {
+                    let joined = sparse_paths
+                        .iter()
+                        .map(|p| format!("\"{}\"", p.replace('\\', "\\\\").replace('"', "\\\"")))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    output.push_str(&format!("sparse_paths = [{joined}]\n"));
+                }
             }
         }
 
@@ -608,11 +608,10 @@ impl GitManager {
         // Only configure git-level sparse checkout if the submodule directory exists
         // (it may not exist yet if --no-init was used)
         let submodule_exists = std::path::Path::new(path).exists();
-        if submodule_exists
-            && let Some(patterns) = sparse_paths {
-                let use_git_default = self.effective_use_git_default_sparse_checkout(name);
-                self.configure_sparse_checkout(path, &patterns, use_git_default)?;
-            }
+        if submodule_exists && let Some(patterns) = sparse_paths {
+            let use_git_default = self.effective_use_git_default_sparse_checkout(name);
+            self.configure_sparse_checkout(path, &patterns, use_git_default)?;
+        }
         Ok(())
     }
 
@@ -846,29 +845,28 @@ impl GitManager {
 
     /// Initialize submodule - add it first if not registered, then initialize
     pub fn init_submodule(&mut self, name: &str) -> Result<(), SubmoduleError> {
-        let (
-            path_str,
-            url_str,
-            branch,
-            ignore,
-            update,
-            fetch_recurse,
-            shallow,
-            sparse_paths_opt,
-        ) = {
-            let config = self.config
-                .get_submodule(name)
-                .ok_or_else(|| SubmoduleError::SubmoduleNotFound {
+        let (path_str, url_str, branch, ignore, update, fetch_recurse, shallow, sparse_paths_opt) = {
+            let config = self.config.get_submodule(name).ok_or_else(|| {
+                SubmoduleError::SubmoduleNotFound {
                     name: name.to_string(),
-                })?;
+                }
+            })?;
 
-            let path_str = config.path.as_ref().ok_or_else(|| {
-                SubmoduleError::ConfigError("No path configured for submodule".to_string())
-            })?.clone();
+            let path_str = config
+                .path
+                .as_ref()
+                .ok_or_else(|| {
+                    SubmoduleError::ConfigError("No path configured for submodule".to_string())
+                })?
+                .clone();
 
-            let url_str = config.url.as_ref().ok_or_else(|| {
-                SubmoduleError::ConfigError("No URL configured for submodule".to_string())
-            })?.clone();
+            let url_str = config
+                .url
+                .as_ref()
+                .ok_or_else(|| {
+                    SubmoduleError::ConfigError("No URL configured for submodule".to_string())
+                })?
+                .clone();
 
             let sparse_paths_opt = self
                 .config
@@ -1145,9 +1143,9 @@ impl GitManager {
             }
         }
         if let Some(fetch_recurse) = &entry.fetch_recurse {
-            let val = fetch_recurse.to_string();
+            let val = fetch_recurse.as_config_value();
             if !val.is_empty() {
-                kv.push(("fetch".into(), format!("\"{val}\"")));
+                kv.push(("fetchRecurse".into(), format!("\"{val}\"")));
             }
         }
         if let Some(update) = &entry.update {
@@ -1160,18 +1158,20 @@ impl GitManager {
             kv.push(("active".into(), active.to_string()));
         }
         if let Some(shallow) = entry.shallow
-            && shallow {
-                kv.push(("shallow".into(), "true".into()));
-            }
+            && shallow
+        {
+            kv.push(("shallow".into(), "true".into()));
+        }
         if let Some(sparse_paths) = &entry.sparse_paths
-            && !sparse_paths.is_empty() {
-                let joined = sparse_paths
-                    .iter()
-                    .map(|p| format!("\"{}\"", p.replace('\\', "\\\\").replace('"', "\\\"")))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                kv.push(("sparse_paths".into(), format!("[{joined}]")));
-            }
+            && !sparse_paths.is_empty()
+        {
+            let joined = sparse_paths
+                .iter()
+                .map(|p| format!("\"{}\"", p.replace('\\', "\\\\").replace('"', "\\\"")))
+                .collect::<Vec<_>>()
+                .join(", ");
+            kv.push(("sparse_paths".into(), format!("[{joined}]")));
+        }
         kv
     }
 
@@ -1181,6 +1181,7 @@ impl GitManager {
         "url",
         "branch",
         "ignore",
+        "fetchRecurse",
         "fetch",
         "update",
         "active",
@@ -1189,7 +1190,8 @@ impl GitManager {
     ];
 
     /// Known [defaults] key names.
-    const KNOWN_DEFAULTS_KEYS: &'static [&'static str] = &["ignore", "fetch", "update"];
+    const KNOWN_DEFAULTS_KEYS: &'static [&'static str] =
+        &["ignore", "fetchRecurse", "fetch", "update"];
 
     /// Return the key name if `line` is a key = value assignment for one of `known_keys`, else None.
     fn line_key<'a>(line: &str, known_keys: &[&'a str]) -> Option<&'a str> {
@@ -1201,9 +1203,10 @@ impl GitManager {
         for key in known_keys {
             // Match "key =" or "key=" at start of trimmed line
             if let Some(rest) = trimmed.strip_prefix(key)
-                && (rest.starts_with('=') || rest.starts_with(" =")) {
-                    return Some(key);
-                }
+                && (rest.starts_with('=') || rest.starts_with(" ="))
+            {
+                return Some(key);
+            }
         }
         None
     }
@@ -1283,9 +1286,9 @@ impl GitManager {
                 }
             }
             if let Some(fetch_recurse) = &defaults.fetch_recurse {
-                let val = fetch_recurse.to_string();
+                let val = fetch_recurse.as_config_value();
                 if !val.is_empty() {
-                    kv.push(("fetch".into(), format!("\"{val}\"")));
+                    kv.push(("fetchRecurse".into(), format!("\"{val}\"")));
                 }
             }
             if let Some(update) = &defaults.update {
@@ -1921,9 +1924,10 @@ impl GitManager {
                 .collect();
             for (name, path) in names_and_paths {
                 if let Ok(patterns) = git_ops.get_sparse_patterns(&path)
-                    && !patterns.is_empty() {
-                        entries.set_sparse_paths_for(&name, patterns);
-                    }
+                    && !patterns.is_empty()
+                {
+                    entries.set_sparse_paths_for(&name, patterns);
+                }
             }
 
             // Build a Config from the SubmoduleEntries
@@ -1983,10 +1987,7 @@ mod tests {
         let expected_paths: Vec<String> = vec!["path/a".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(
-                &submodule_path.to_string_lossy(),
-                &expected_paths,
-            )
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         assert_eq!(status, SparseStatus::NotConfigured);
@@ -2009,10 +2010,7 @@ mod tests {
         let expected_paths = vec!["path/a".to_string(), "path/b".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(
-                &submodule_path.to_string_lossy(),
-                &expected_paths,
-            )
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         assert_eq!(status, SparseStatus::Correct);
@@ -2037,13 +2035,54 @@ mod tests {
         let expected_paths = vec!["path/a".to_string(), "path/b".to_string()];
 
         let status = manager
-            .check_sparse_checkout_status(
-                &submodule_path.to_string_lossy(),
-                &expected_paths,
-            )
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         assert_eq!(status, SparseStatus::Correct);
+    }
+
+    #[test]
+    fn test_write_full_config_fetch_recurse_round_trips() {
+        // Regression for the fetch-recurse round-trip bug: submod must be able to
+        // read back the fetch-recurse setting it writes. The writer previously emitted
+        // `fetch = "true"/"false"` — both the wrong TOML key (neither the documented
+        // `fetchRecurse` nor the field `fetch_recurse`) and the git-config value form
+        // (`true`/`false` instead of `always`/`never`) — so reloading silently dropped it.
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path().join("submod.toml");
+        let mut manager = create_test_manager(temp_dir.path(), config_path.clone());
+
+        manager.config.defaults.fetch_recurse = Some(SerializableFetchRecurse::Always);
+        manager.config.add_submodule(
+            "mymod".to_string(),
+            SubmoduleEntry::new(
+                Some("https://example.com/repo.git".to_string()),
+                Some("libs/mymod".to_string()),
+                None,
+                None,
+                None,
+                Some(SerializableFetchRecurse::Never),
+                Some(true),
+                None,
+                None,
+            ),
+        );
+
+        manager.write_full_config().expect("write_full_config");
+
+        let written = fs::read_to_string(&config_path).unwrap();
+        let reloaded: Config = toml::from_str(&written)
+            .expect("config submod writes must be valid TOML it can parse back");
+        assert_eq!(
+            reloaded.defaults.fetch_recurse,
+            Some(SerializableFetchRecurse::Always),
+            "defaults fetch-recurse must survive a write/read round-trip; written file:\n{written}"
+        );
+        assert_eq!(
+            reloaded.submodules.get("mymod").unwrap().fetch_recurse,
+            Some(SerializableFetchRecurse::Never),
+            "per-submodule fetch-recurse must survive a write/read round-trip; written file:\n{written}"
+        );
     }
 
     #[test]
@@ -2066,10 +2105,7 @@ mod tests {
         ];
 
         let status = manager
-            .check_sparse_checkout_status(
-                &submodule_path.to_string_lossy(),
-                &expected_paths,
-            )
+            .check_sparse_checkout_status(&submodule_path.to_string_lossy(), &expected_paths)
             .unwrap();
 
         match status {

--- a/src/options.rs
+++ b/src/options.rs
@@ -290,6 +290,25 @@ pub enum SerializableFetchRecurse {
     Unspecified,
 }
 
+impl SerializableFetchRecurse {
+    /// The value as written to / read from `submod.toml`.
+    ///
+    /// This is the serde kebab-case form (`on-demand` / `always` / `never`) and is
+    /// deliberately distinct from [`GitmodulesConvert::to_gitmodules`], which uses
+    /// git's `true`/`false` encoding for `.gitmodules` and `.git/config`. The TOML
+    /// writers must use this form so values round-trip back through the `Deserialize`
+    /// impl (which expects the kebab-case spelling).
+    #[must_use]
+    pub const fn as_config_value(&self) -> &'static str {
+        match self {
+            Self::OnDemand => "on-demand",
+            Self::Always => "always",
+            Self::Never => "never",
+            Self::Unspecified => "",
+        }
+    }
+}
+
 impl GitmodulesConvert for SerializableFetchRecurse {
     /// Get the git key for the fetch recurse submodule setting
     fn gitmodules_key(&self) -> &'static str {
@@ -909,6 +928,21 @@ mod tests {
         assert_eq!(
             SerializableFetchRecurse::OnDemand.gitmodules_key(),
             "fetchRecurseSubmodules"
+        );
+    }
+
+    #[test]
+    fn test_fetch_recurse_as_config_value_uses_serde_form_not_git_bools() {
+        // The submod.toml value form must be the serde kebab spelling so it round-trips
+        // through Deserialize — NOT git's true/false encoding used by to_gitmodules.
+        assert_eq!(SerializableFetchRecurse::OnDemand.as_config_value(), "on-demand");
+        assert_eq!(SerializableFetchRecurse::Always.as_config_value(), "always");
+        assert_eq!(SerializableFetchRecurse::Never.as_config_value(), "never");
+        assert_eq!(SerializableFetchRecurse::Unspecified.as_config_value(), "");
+        // Guard against regressing to the git-config encoding for the TOML value.
+        assert_ne!(
+            SerializableFetchRecurse::Always.as_config_value(),
+            SerializableFetchRecurse::Always.to_gitmodules()
         );
     }
 

--- a/tests/command_contract_tests.rs
+++ b/tests/command_contract_tests.rs
@@ -839,13 +839,18 @@ mod tests {
             "Global update not saved"
         );
         // The `--fetch always` CLI value maps to SerializableFetchRecurse::Always.
-        // That variant's TOML serialization (via to_gitmodules()) uses git's native
-        // fetchRecurseSubmodules encoding: "true" means "always fetch".
-        // The TOML config therefore stores `fetch = "true"` not `fetch = "always"`.
+        // It must be written under the documented `fetchRecurse` key using the serde
+        // value form (`always`), NOT the git-config `true`/`false` encoding — otherwise
+        // submod cannot read its own config back (see the fetch-recurse round-trip fix).
         assert!(
-            config.contains("fetch = \"true\""),
-            "Global fetch not saved; config: {config}"
+            config.contains("fetchRecurse = \"always\""),
+            "Global fetch not saved in round-trippable form; config: {config}"
         );
+
+        // Reloading must actually parse the value back (guards against silent drop).
+        harness
+            .run_submod_success(&["check"])
+            .expect("submod check should succeed after change-global");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Fixes the **P0-3** finding from the test audit (#62): submod silently dropped the documented `fetchRecurse` config key and could not read back the fetch-recurse setting it wrote.

Two distinct defects, both real and round-trip-breaking:

1. **Read side** — the serde field is `fetch_recurse` with no rename, while the README (and the test suite, and the bundled sample) document the key as `fetchRecurse`. So a config written per the docs deserialized to `None` — the value was silently dropped.
2. **Write side** — both config writers (`save_config` and `write_full_config`) emitted `fetch = "<to_gitmodules>"`. That's the **wrong key** (`fetch`, neither documented `fetchRecurse` nor field `fetch_recurse`) **and the wrong value form** (`to_gitmodules()` yields git's `true`/`false`, but the deserializer expects the serde `always`/`never`). So submod could not parse a config it had just written.

The existing `test_change_global_sets_update_and_fetch` actually **enshrined** the bug — it asserted the output contained `fetch = "true"`, with a comment rationalizing it.

## Approach

- Standardize on the documented **`fetchRecurse`** key via `#[serde(rename = "fetchRecurse")]` on all three structs (`SubmoduleGitOptions`, `SubmoduleDefaults`, `SubmoduleEntry`). `rename` (not `alias`) is required because `Config::load` merges layers through figment at the raw-dict level — an `alias` would leave the file layer (`fetchRecurse`) and the CLI-provider layer (`fetch_recurse`) as two different keys, which serde then rejects as a duplicate field. A single canonical spelling matches how `ignore`/`update` already behave.
- Add `SerializableFetchRecurse::as_config_value()` returning the serde kebab form (`on-demand`/`always`/`never`), explicitly distinct from `to_gitmodules()` (git's `true`/`false`), and use it in both writers.
- Update the writer key to `fetchRecurse` and add it to the known-key lists.
- Update the bundled `sample_config/submod.toml` comments.

## Tests (TDD — each watched fail first)

- `test_config_toml_fetch_recurse_camelcase_key_is_parsed` — deserializes the documented `fetchRecurse` key and asserts the **parsed** value (not file text).
- `test_write_full_config_fetch_recurse_round_trips` — writes config via `write_full_config`, reloads, asserts `Always`/`Never` survive — the core regression test.
- `test_fetch_recurse_as_config_value_uses_serde_form_not_git_bools` — pins the TOML value form against regressing to the git encoding.
- Corrects `test_change_global_sets_update_and_fetch` to assert the round-trippable `fetchRecurse = "always"` and that a subsequent `check` succeeds.

Full suite: **518 tests pass**.

## Notes

- `config.rs` and `git_manager.rs` also pick up rustfmt (1.8.0) normalization of pre-existing unformatted lines — required to pass the `cargo fmt` pre-commit gate, which currently fails on ~154 pre-existing diffs across the repo. Reformatting was confined to the two files this PR already touches.
- **Follow-ups (not in this PR):** the JSON schemas (`schemas/v1.0.0`, `schemas/v1.1.0`) still define the key as `fetch` with `additionalProperties: false`, so they'd reject the documented `fetchRecurse`; and `schemas/v1.1.0/...json` is currently malformed JSON (a stray `""`). The repo-wide rustfmt drift (~154 diffs across 13 files) is also worth a standalone `style:` commit.

Closes the P0-3 item in #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
