### PR TITLE
test(fallback): exercise CLI last-resort add + assert fallback warnings (#62 P0-1)

### DIFF
--- a/src/git_ops/mod.rs
+++ b/src/git_ops/mod.rs
@@ -171,6 +171,7 @@ pub struct GitOpsManager {
     gix_ops: Option<GixOperations>,
     git2_ops: Git2Operations,
     verbose: bool,
+    force_cli_add: bool,
 }
 
 /// Implement `GitOperations` for `GitOpsManager`, using gix first and falling back to git2 if gix fails
@@ -185,6 +186,7 @@ impl GitOpsManager {
             gix_ops,
             git2_ops,
             verbose,
+            force_cli_add: false,
         })
     }
 
@@ -203,13 +205,35 @@ impl GitOpsManager {
             gix_ops: None,
             git2_ops,
             verbose,
+            force_cli_add: false,
         })
+    }
+
+    /// Create a `GitOpsManager` that routes `add_submodule` straight to its CLI
+    /// last-resort path, bypassing both the gix and git2 backends.
+    ///
+    /// The CLI branch in `add_submodule` only runs when *both* in-process
+    /// backends fail — a condition that cannot be reproduced offline with real
+    /// inputs, since git2 and the git CLI clone from the same URL. This
+    /// fault-injection seam makes that otherwise-unreachable last resort
+    /// exercisable for correct results: the entire CLI branch — including its
+    /// cleanup of partial state left by a failed git2 attempt — runs unmodified.
+    pub fn forcing_cli_add(repo_path: Option<&Path>, verbose: bool) -> Result<Self> {
+        let mut manager = Self::new(repo_path, verbose)?;
+        manager.force_cli_add = true;
+        Ok(manager)
     }
 
     /// Whether the optimistic gix backend is currently active. When `false`,
     /// every operation is served by git2 (the fallback backend).
     pub fn gix_enabled(&self) -> bool {
         self.gix_ops.is_some()
+    }
+
+    /// Whether `add_submodule` is forced through its CLI last-resort path,
+    /// bypassing both in-process backends. Normally `false`.
+    pub fn forces_cli_add(&self) -> bool {
+        self.force_cli_add
     }
 
     /// Return the working directory of the underlying git repository, if any.
@@ -336,11 +360,21 @@ impl GitOperations for GitOpsManager {
         // the correct `submodule.clone() + add_finalize()` sequence.
         // CLI is kept as a last-resort safety net and sets current_dir to the superproject
         // workdir so it works regardless of the process's CWD.
-        self.try_with_fallback_mut(
-            |gix| gix.add_submodule(opts),
-            |git2| git2.add_submodule(opts),
-        )
-        .or_else(|git2_err| {
+        //
+        // The `force_cli_add` fault-injection seam short-circuits both in-process
+        // backends so the CLI last resort can be exercised directly (see
+        // `GitOpsManager::forcing_cli_add`).
+        let in_process = if self.force_cli_add {
+            Err(anyhow::anyhow!(
+                "in-process git backends bypassed (forcing CLI last resort)"
+            ))
+        } else {
+            self.try_with_fallback_mut(
+                |gix| gix.add_submodule(opts),
+                |git2| git2.add_submodule(opts),
+            )
+        };
+        in_process.or_else(|git2_err| {
             let workdir = self
                 .git2_ops
                 .workdir()

--- a/tests/fallback_tests.rs
+++ b/tests/fallback_tests.rs
@@ -974,3 +974,224 @@ mod git2_fallback_injection_tests {
         );
     }
 }
+
+// ============================================================
+// CLI last-resort path of add_submodule
+// ============================================================
+//
+// `add_submodule`'s `.or_else(...)` CLI branch only runs when *both* in-process
+// backends (gix and git2) fail. That condition cannot be reproduced offline with
+// real inputs — git2 and the git CLI clone from the same URL, so anything that
+// breaks git2 breaks the CLI too. `GitOpsManager::forcing_cli_add` is a fault-
+// injection seam that bypasses both in-process backends so the otherwise-
+// unreachable CLI last resort runs *unmodified* and can be checked for correct
+// results, including its cleanup of partial state left by a failed git2 attempt.
+
+#[cfg(test)]
+mod cli_last_resort_tests {
+    use super::*;
+
+    /// The seam itself: `forcing_cli_add` must flag the manager to route
+    /// `add_submodule` through the CLI last resort, while the normal constructor
+    /// does not. This anchors non-vacuousness for the whole module — when the
+    /// flag is set, any resulting git state must have come from the CLI branch
+    /// (both in-process backends are bypassed).
+    #[test]
+    fn forcing_cli_add_enables_cli_seam() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+
+        let normal = GitOpsManager::new(Some(&harness.work_dir), false).expect("mgr");
+        assert!(
+            !normal.forces_cli_add(),
+            "GitOpsManager::new must not force the CLI last resort"
+        );
+
+        let forced = GitOpsManager::forcing_cli_add(Some(&harness.work_dir), false).expect("mgr");
+        assert!(
+            forced.forces_cli_add(),
+            "GitOpsManager::forcing_cli_add must force the CLI last resort"
+        );
+    }
+
+    /// The CLI last resort must produce *correct git state*: an index gitlink at
+    /// mode 160000, a `.gitmodules` entry, a `submodule.*` config section, and the
+    /// path must appear in `list_submodules`. Both in-process backends are
+    /// bypassed, so this state can only have come from the CLI branch.
+    #[test]
+    fn cli_last_resort_add_produces_real_git_state() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let remote = harness
+            .create_test_remote("cli_add")
+            .expect("create remote");
+        let remote_url = format!("file://{}", remote.display());
+
+        let mut mgr = GitOpsManager::forcing_cli_add(Some(&harness.work_dir), false).expect("mgr");
+
+        let opts = SubmoduleAddOptions {
+            url: remote_url,
+            path: std::path::PathBuf::from("lib/cliadd"),
+            name: "cliadd-sub".to_string(),
+            branch: None,
+            ignore: None,
+            update: None,
+            fetch_recurse: None,
+            shallow: false,
+            no_init: false,
+        };
+        mgr.add_submodule(&opts)
+            .expect("CLI last-resort add_submodule should succeed");
+
+        assert_eq!(
+            harness.index_gitlink_mode("lib/cliadd").as_deref(),
+            Some("160000"),
+            "CLI add must stage a gitlink at mode 160000"
+        );
+        assert!(
+            harness.gitmodules_entries().contains("lib/cliadd"),
+            "CLI add must write the .gitmodules entry"
+        );
+        // `git submodule add --name cliadd-sub` keys .git/config by the submodule
+        // *name* (submodule.cliadd-sub.url), unlike git2 which keys by path.
+        assert!(
+            harness.submodule_config_entries().contains("cliadd-sub"),
+            "CLI add must write the submodule.* config section (keyed by name)"
+        );
+        let subs = mgr.list_submodules().expect("list_submodules");
+        assert!(
+            subs.iter().any(|p| p == "lib/cliadd"),
+            "CLI add path must appear in list_submodules, got: {subs:?}"
+        );
+    }
+
+    /// The CLI branch's first job is to clean up partial state a failed git2
+    /// attempt may have left behind (a stale `.gitmodules` section, a config
+    /// section, an internal `.git/modules/<name>` dir, a staged index entry) and
+    /// then re-add cleanly. Seed exactly that leftover state for the target name,
+    /// then run the forced CLI add and assert it both succeeds and ends with the
+    /// *real* url — not the stale seed — proving the cleanup ran.
+    #[test]
+    fn cli_last_resort_cleans_up_partial_state_and_succeeds() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let remote = harness
+            .create_test_remote("cli_reinit")
+            .expect("create remote");
+        let remote_url = format!("file://{}", remote.display());
+
+        // Simulate the debris a half-finished git2 add_submodule leaves behind:
+        // a stale .gitmodules section (with a bogus url), a stale config section,
+        // and an internal modules directory — all keyed by the submodule name.
+        let stale_gitmodules = "[submodule \"cleanup-sub\"]\n\tpath = lib/cleanup\n\turl = https://example.com/STALE.git\n";
+        std::fs::write(harness.work_dir.join(".gitmodules"), stale_gitmodules)
+            .expect("seed stale .gitmodules");
+        harness.git_stdout(&[
+            "config",
+            "submodule.cleanup-sub.url",
+            "https://example.com/STALE.git",
+        ]);
+        std::fs::create_dir_all(harness.work_dir.join(".git/modules/cleanup-sub"))
+            .expect("seed stale internal modules dir");
+
+        let mut mgr = GitOpsManager::forcing_cli_add(Some(&harness.work_dir), false).expect("mgr");
+
+        let opts = SubmoduleAddOptions {
+            url: remote_url.clone(),
+            path: std::path::PathBuf::from("lib/cleanup"),
+            name: "cleanup-sub".to_string(),
+            branch: None,
+            ignore: None,
+            update: None,
+            fetch_recurse: None,
+            shallow: false,
+            no_init: false,
+        };
+        mgr.add_submodule(&opts)
+            .expect("CLI last-resort add must clean up partial state and succeed");
+
+        assert_eq!(
+            harness.index_gitlink_mode("lib/cleanup").as_deref(),
+            Some("160000"),
+            "CLI add must stage the gitlink after cleaning up partial state"
+        );
+        let gitmodules = harness.gitmodules_entries();
+        assert!(
+            gitmodules.contains(&remote_url),
+            "the real url must replace the stale seed, got: {gitmodules}"
+        );
+        assert!(
+            !gitmodules.contains("STALE.git"),
+            "the stale .gitmodules section must have been cleaned up, got: {gitmodules}"
+        );
+    }
+
+    /// The audit flagged that fallback warning logs are never asserted. gix's
+    /// `add_submodule` always errors, so a verbose run of the real binary must
+    /// emit the gix→git2 fallback warning to stderr.
+    #[test]
+    fn fallback_warning_is_logged_in_verbose_mode() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let remote = harness
+            .create_test_remote("warn_add")
+            .expect("create remote");
+        let remote_url = format!("file://{}", remote.display());
+
+        let output = harness
+            .run_submod(&[
+                "--verbose",
+                "add",
+                &remote_url,
+                "--name",
+                "warn-sub",
+                "--path",
+                "lib/warn",
+            ])
+            .expect("run submod --verbose add");
+        assert!(
+            output.status.success(),
+            "verbose add should still succeed via fallback; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("falling back to git2"),
+            "verbose mode must log the gix→git2 fallback warning, got stderr: {stderr}"
+        );
+    }
+
+    /// Non-vacuousness for the warning assertion above: without `--verbose`, the
+    /// same fallback occurs silently. This proves the assertion discriminates on
+    /// the verbose flag rather than matching unconditional output.
+    #[test]
+    fn fallback_warning_is_silent_without_verbose() {
+        let harness = TestHarness::new().expect("harness");
+        harness.init_git_repo().expect("init repo");
+        let remote = harness
+            .create_test_remote("quiet_add")
+            .expect("create remote");
+        let remote_url = format!("file://{}", remote.display());
+
+        let output = harness
+            .run_submod(&[
+                "add",
+                &remote_url,
+                "--name",
+                "quiet-sub",
+                "--path",
+                "lib/quiet",
+            ])
+            .expect("run submod add");
+        assert!(
+            output.status.success(),
+            "non-verbose add should succeed via fallback; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("falling back to git2"),
+            "non-verbose mode must not log the fallback warning, got stderr: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Completes the deferred portion of **P0-1** from the test-suite audit (#62). PR #65 added the git2 failure-injection seam; this PR closes the two items it explicitly deferred:

1. The **CLI last-resort** path in `add_submodule` was dead code from the suite's perspective.
2. The **gix→git2 fallback warning logs** were never asserted.

## Why these needed work

The CLI branch in `add_submodule` only runs when **both** in-process backends (gix and git2) fail. That can't be reproduced offline with real inputs — git2 and the git CLI clone from the same URL, so anything that breaks git2 breaks the CLI too. A fault-injection seam is the only deterministic way in.

## Production change (mirrors the merged `without_gix` pattern)

- `GitOpsManager::forcing_cli_add(...)` — constructs a manager whose `add_submodule` short-circuits both backends so the CLI branch runs **unmodified**, including its cleanup of partial state a failed git2 attempt leaves behind.
- `forces_cli_add()` — accessor anchoring seam non-vacuousness.

Normal construction (`new`, `without_gix`) sets the flag `false`, so production behavior is unchanged.

## Tests (`tests/fallback_tests.rs::cli_last_resort_tests`)

- **seam proof** — `forces_cli_add()` true only under the seam.
- **CLI add produces real git state** — gitlink at `160000`, `.gitmodules` entry, `submodule.*` config (keyed by **name** under the CLI, unlike git2's path key), and `list_submodules`. Both backends bypassed, so the state can only have come from the CLI branch.
- **CLI add cleans up partial state** — seeds the debris a half-finished git2 add leaves (stale `.gitmodules` section + config section + `.git/modules/<name>` dir), then asserts the forced CLI add cleans it and re-adds with the **real** url (not the stale seed).
- **fallback warning logs** — a `--verbose` run of the real binary emits the gix→git2 fallback warning to stderr; the non-verbose run stays silent. The pair proves the assertion discriminates on `--verbose` rather than matching unconditional output.

## Rigor

Confirmed the CLI branch is load-bearing by temporarily sabotaging the `git submodule add` subcommand and observing both state tests fail, then reverting. **534 tests pass** (529 prior + 5 new); clippy clean.

Addresses the remaining P0-1 sub-items in #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)