### PR TITLE
fix(update): checkout submodule to recorded gitlink commit (#62 P1)

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -50,8 +50,7 @@ fn line_key_new<'a>(line: &str, known_keys: &[&'a str]) -> Option<&'a str> {
         return None;
     }
     for key in known_keys {
-        if trimmed.starts_with(key) {
-            let rest = &trimmed[key.len()..];
+        if let Some(rest) = trimmed.strip_prefix(key) {
             if rest.starts_with('=') || rest.starts_with(" =") {
                 return Some(key);
             }
@@ -98,7 +97,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             for line in &lines {
                 black_box(line_key_old(black_box(line), black_box(&keys)));
             }
-        })
+        });
     });
 
     c.bench_function("line_key_new", |b| {
@@ -106,7 +105,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             for line in &lines {
                 black_box(line_key_new(black_box(line), black_box(&keys)));
             }
-        })
+        });
     });
 }
 

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -2002,7 +2002,7 @@ mod tests {
         // Create .git/info/sparse-checkout with the expected paths
         let info_dir = submodule_path.join(".git").join("info");
         fs::create_dir_all(&info_dir).unwrap();
-        let content = format!("{}\npath/a\npath/b\n", SPARSE_DENY_ALL);
+        let content = format!("{SPARSE_DENY_ALL}\npath/a\npath/b\n");
         fs::write(info_dir.join("sparse-checkout"), content).unwrap();
 
         let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
@@ -2027,7 +2027,7 @@ mod tests {
         let info_dir = submodule_path.join(".git").join("info");
         fs::create_dir_all(&info_dir).unwrap();
         // File has path/a, path/b AND an extra path/c not in expected_paths
-        let content = format!("{}\npath/a\npath/b\npath/c\n", SPARSE_DENY_ALL);
+        let content = format!("{SPARSE_DENY_ALL}\npath/a\npath/b\npath/c\n");
         fs::write(info_dir.join("sparse-checkout"), content).unwrap();
 
         let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
@@ -2094,7 +2094,7 @@ mod tests {
         // sparse-checkout has only path/a; path/b is expected but absent
         let info_dir = submodule_path.join(".git").join("info");
         fs::create_dir_all(&info_dir).unwrap();
-        let content = format!("{}\npath/a\n", SPARSE_DENY_ALL);
+        let content = format!("{SPARSE_DENY_ALL}\npath/a\n");
         fs::write(info_dir.join("sparse-checkout"), content).unwrap();
 
         let manager = create_test_manager(temp_dir.path(), temp_dir.path().join("submod.toml"));
@@ -2113,7 +2113,7 @@ mod tests {
                 assert_eq!(expected, vec!["path/a".to_string(), "path/b".to_string()]);
                 assert_eq!(actual, vec!["path/a".to_string()]);
             }
-            _ => panic!("Expected Mismatch, got {:?}", status),
+            _ => panic!("Expected Mismatch, got {status:?}"),
         }
     }
 }

--- a/src/git_ops/gix_ops.rs
+++ b/src/git_ops/gix_ops.rs
@@ -469,7 +469,16 @@ impl GitOperations for GixOperations {
             match opts.strategy {
                 crate::options::SerializableUpdate::Checkout
                 | crate::options::SerializableUpdate::Unspecified => {
-                    // Fetch complete above
+                    // The fetch above only updated the object store and remote
+                    // tracking refs; the worktree still needs to be checked out
+                    // to the commit recorded as the superproject's gitlink. gix
+                    // has no worktree-checkout for an existing submodule here, so
+                    // delegate to git2's `submodule.update()`, which performs the
+                    // checkout. Without this, `update` silently fetched but left
+                    // the worktree stranded behind its recorded commit (#62 P1).
+                    return Err(anyhow::anyhow!(
+                        "gix cannot checkout submodule to its recorded commit; falling back to git2"
+                    ));
                 }
                 crate::options::SerializableUpdate::Merge => {
                     return Err(anyhow::anyhow!(

--- a/src/git_ops/mod.rs
+++ b/src/git_ops/mod.rs
@@ -226,13 +226,13 @@ impl GitOpsManager {
 
     /// Whether the optimistic gix backend is currently active. When `false`,
     /// every operation is served by git2 (the fallback backend).
-    pub fn gix_enabled(&self) -> bool {
+    pub const fn gix_enabled(&self) -> bool {
         self.gix_ops.is_some()
     }
 
     /// Whether `add_submodule` is forced through its CLI last-resort path,
     /// bypassing both in-process backends. Normally `false`.
-    pub fn forces_cli_add(&self) -> bool {
+    pub const fn forces_cli_add(&self) -> bool {
         self.force_cli_add
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1240,7 +1240,7 @@ mod tests {
 
     #[test]
     fn test_branch_set_branch_empty_returns_default() {
-        let result = SerializableBranch::set_branch(Some("".to_string())).unwrap();
+        let result = SerializableBranch::set_branch(Some(String::new())).unwrap();
         // Empty string → default
         assert_eq!(result, SerializableBranch::default());
     }

--- a/src/shells.rs
+++ b/src/shells.rs
@@ -95,6 +95,120 @@ impl TryFrom<AotShell> for Shell {
     }
 }
 
+impl TryFrom<Shell> for AotShell {
+    type Error = String;
+
+    /// Attempts to convert a `Shell` to an `AotShell`.
+    fn try_from(shell: Shell) -> Result<Self, Self::Error> {
+        match shell {
+            Shell::Bash => Ok(Self::Bash),
+            Shell::Elvish => Ok(Self::Elvish),
+            Shell::Fish => Ok(Self::Fish),
+            Shell::PowerShell => Ok(Self::PowerShell),
+            Shell::Zsh => Ok(Self::Zsh),
+            Shell::Nushell => Err("Nushell is not supported in AOT mode".to_string()),
+        }
+    }
+}
+
+impl TryFrom<Shell> for NushellShell {
+    type Error = String;
+
+    /// Attempts to convert a `Shell` to a `NushellShell`.
+    fn try_from(shell: Shell) -> Result<Self, Self::Error> {
+        if shell == Shell::Nushell {
+            Ok(Self)
+        } else {
+            Err("Only Nushell can be converted to NushellShell".to_string())
+        }
+    }
+}
+
+impl TryFrom<NushellShell> for Shell {
+    type Error = String;
+    /// Converts a `NushellShell` to a `Shell`.
+    fn try_from(shell: NushellShell) -> Result<Self, String> {
+        match shell {
+            NushellShell => Ok(Self::Nushell),
+            _ => Err("Only NushellShell can be converted to Shell::Nushell".to_string()),
+        }
+    }
+}
+
+impl Shell {
+    /// Converts the `Shell` enum to a shell enum implementing `clap_complete::Generator` (as a Box pointer).
+    pub fn try_to_clap_complete(&self) -> Result<Box<dyn Generator>, String> {
+        match self {
+            Self::Bash => Ok(Box::new(AotShell::Bash)),
+            Self::Elvish => Ok(Box::new(AotShell::Elvish)),
+            Self::Fish => Ok(Box::new(AotShell::Fish)),
+            Self::PowerShell => Ok(Box::new(AotShell::PowerShell)),
+            Self::Zsh => Ok(Box::new(AotShell::Zsh)),
+            Self::Nushell => Ok(Box::new(NushellShell)),
+        }
+    }
+
+    /// Tries to find the shell from a path to its executable.
+    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Option<Self> {
+        Self::parse_shell_from_path(path.as_ref())
+    }
+
+    fn parse_shell_from_path(path: &std::path::Path) -> Option<Self> {
+        let name = path.file_stem()?.to_str()?;
+        match name {
+            "bash" => Some(Self::Bash),
+            "elvish" => Some(Self::Elvish),
+            "fish" => Some(Self::Fish),
+            "powershell" | "pwsh" | "powershell_ise" => Some(Self::PowerShell),
+            "zsh" => Some(Self::Zsh),
+            "nu" | "nushell" => Some(Self::Nushell),
+            _ => None,
+        }
+    }
+
+    /// Attempts to find the shell from the `SHELL` environment variable.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        if let Some(env_shell) = std::env::var_os("SHELL") {
+            Self::parse_shell_from_path(std::path::Path::new(&env_shell))
+        } else {
+            None
+        }
+    }
+}
+
+impl Generator for Shell {
+    /// Returns the file name for the completion file.
+    fn file_name(&self, name: &str) -> String {
+        let shell_self = self.try_to_clap_complete();
+        shell_self.map_or_else(|_| format!("{name}.nu"), |s| s.file_name(name)) // Default to Nushell if conversion fails
+    }
+
+    /// Generates the completion file for the given command and writes it to the provided buffer.
+    fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
+        let shell_self = self.try_to_clap_complete();
+        shell_self
+            .map(|s| {
+                s.try_generate(cmd, buf)
+                    .unwrap_or_else(|e| panic!("failed to write completion file: {e}"));
+            })
+            .unwrap_or_else(|_| panic!("failed to write completion file"));
+    }
+
+    /// Attempts to generate the completion file for the given command and writes it to the provided buffer.
+    fn try_generate(
+        &self,
+        cmd: &clap::Command,
+        buf: &mut dyn std::io::Write,
+    ) -> Result<(), std::io::Error> {
+        let shell_self = self.try_to_clap_complete();
+        match shell_self {
+            Ok(s) => s.try_generate(cmd, buf),
+            Err(e) => Err(std::io::Error::other(e)),
+        }
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -331,121 +445,7 @@ mod tests {
             let mut buf = Vec::new();
             // clap_complete::generate sets bin_name internally
             clap_complete::generate(*shell, &mut cmd, "test-cmd", &mut buf);
-            assert!(!buf.is_empty(), "Empty output for {:?}", shell);
-        }
-    }
-}
-
-impl TryFrom<Shell> for AotShell {
-    type Error = String;
-
-    /// Attempts to convert a `Shell` to an `AotShell`.
-    fn try_from(shell: Shell) -> Result<Self, Self::Error> {
-        match shell {
-            Shell::Bash => Ok(Self::Bash),
-            Shell::Elvish => Ok(Self::Elvish),
-            Shell::Fish => Ok(Self::Fish),
-            Shell::PowerShell => Ok(Self::PowerShell),
-            Shell::Zsh => Ok(Self::Zsh),
-            Shell::Nushell => Err("Nushell is not supported in AOT mode".to_string()),
-        }
-    }
-}
-
-impl TryFrom<Shell> for NushellShell {
-    type Error = String;
-
-    /// Attempts to convert a `Shell` to a `NushellShell`.
-    fn try_from(shell: Shell) -> Result<Self, Self::Error> {
-        if shell == Shell::Nushell {
-            Ok(Self)
-        } else {
-            Err("Only Nushell can be converted to NushellShell".to_string())
-        }
-    }
-}
-
-impl TryFrom<NushellShell> for Shell {
-    type Error = String;
-    /// Converts a `NushellShell` to a `Shell`.
-    fn try_from(shell: NushellShell) -> Result<Self, String> {
-        match shell {
-            NushellShell => Ok(Self::Nushell),
-            _ => Err("Only NushellShell can be converted to Shell::Nushell".to_string()),
-        }
-    }
-}
-
-impl Shell {
-    /// Converts the `Shell` enum to a shell enum implementing `clap_complete::Generator` (as a Box pointer).
-    pub fn try_to_clap_complete(&self) -> Result<Box<dyn Generator>, String> {
-        match self {
-            Self::Bash => Ok(Box::new(AotShell::Bash)),
-            Self::Elvish => Ok(Box::new(AotShell::Elvish)),
-            Self::Fish => Ok(Box::new(AotShell::Fish)),
-            Self::PowerShell => Ok(Box::new(AotShell::PowerShell)),
-            Self::Zsh => Ok(Box::new(AotShell::Zsh)),
-            Self::Nushell => Ok(Box::new(NushellShell)),
-        }
-    }
-
-    /// Tries to find the shell from a path to its executable.
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Option<Self> {
-        Self::parse_shell_from_path(path.as_ref())
-    }
-
-    fn parse_shell_from_path(path: &std::path::Path) -> Option<Self> {
-        let name = path.file_stem()?.to_str()?;
-        match name {
-            "bash" => Some(Self::Bash),
-            "elvish" => Some(Self::Elvish),
-            "fish" => Some(Self::Fish),
-            "powershell" | "pwsh" | "powershell_ise" => Some(Self::PowerShell),
-            "zsh" => Some(Self::Zsh),
-            "nu" | "nushell" => Some(Self::Nushell),
-            _ => None,
-        }
-    }
-
-    /// Attempts to find the shell from the `SHELL` environment variable.
-    #[must_use]
-    pub fn from_env() -> Option<Self> {
-        if let Some(env_shell) = std::env::var_os("SHELL") {
-            Self::parse_shell_from_path(std::path::Path::new(&env_shell))
-        } else {
-            None
-        }
-    }
-}
-
-impl Generator for Shell {
-    /// Returns the file name for the completion file.
-    fn file_name(&self, name: &str) -> String {
-        let shell_self = self.try_to_clap_complete();
-        shell_self.map_or_else(|_| format!("{name}.nu"), |s| s.file_name(name)) // Default to Nushell if conversion fails
-    }
-
-    /// Generates the completion file for the given command and writes it to the provided buffer.
-    fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
-        let shell_self = self.try_to_clap_complete();
-        shell_self
-            .map(|s| {
-                s.try_generate(cmd, buf)
-                    .unwrap_or_else(|e| panic!("failed to write completion file: {e}"));
-            })
-            .unwrap_or_else(|_| panic!("failed to write completion file"));
-    }
-
-    /// Attempts to generate the completion file for the given command and writes it to the provided buffer.
-    fn try_generate(
-        &self,
-        cmd: &clap::Command,
-        buf: &mut dyn std::io::Write,
-    ) -> Result<(), std::io::Error> {
-        let shell_self = self.try_to_clap_complete();
-        match shell_self {
-            Ok(s) => s.try_generate(cmd, buf),
-            Err(e) => Err(std::io::Error::other(e)),
+            assert!(!buf.is_empty(), "Empty output for {shell:?}");
         }
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -117,6 +117,7 @@ pub fn path_to_string(path: &std::path::Path) -> Result<String, anyhow::Error> {
 }
 
 /// Convert a `Path` to a `String`, using lossy conversion for non-UTF-8 characters
+#[must_use]
 pub fn path_to_string_lossy(path: &std::path::Path) -> String {
     if let Some(s) = path.to_str() {
         return s.to_string();
@@ -127,6 +128,7 @@ pub fn path_to_string_lossy(path: &std::path::Path) -> String {
 }
 
 /// Convert a `Path` to an `OsString`
+#[must_use]
 pub fn path_to_os_string(path: &std::path::Path) -> std::ffi::OsString {
     path.as_os_str().to_owned()
 }
@@ -256,7 +258,7 @@ mod tests {
     fn test_get_name_empty_name_fallback_path() {
         assert_eq!(
             get_name(
-                Some("".to_string()),
+                Some(String::new()),
                 None,
                 Some(PathBuf::from_iter(["path", "to", "my-module"]).into_os_string())
             )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -215,6 +215,41 @@ impl TestHarness {
         Ok(remote_dir)
     }
 
+    /// Advance the bare remote created by [`create_test_remote`] by one commit on
+    /// `main`, returning the new commit's full SHA. Reuses the working copy left
+    /// at `<temp>/<name>_work` so callers can move the remote forward and then
+    /// observe how `update`/`sync` react to a remote that has new history.
+    pub fn advance_test_remote(&self, name: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let work_copy = self.temp_dir.path().join(format!("{name}_work"));
+
+        fs::write(work_copy.join("ADVANCE.txt"), format!("advanced {name}\n"))?;
+        self.git_cmd()
+            .args(["add", "."])
+            .current_dir(&work_copy)
+            .output()?;
+        self.git_cmd()
+            .args(["commit", "-m", "Advance remote"])
+            .current_dir(&work_copy)
+            .output()?;
+
+        let push_output = self
+            .git_cmd()
+            .args(["push", "--no-verify", "origin", "main"])
+            .current_dir(&work_copy)
+            .output()?;
+        if !push_output.status.success() {
+            let stderr = String::from_utf8_lossy(&push_output.stderr);
+            return Err(format!("Failed to push advance to remote: {stderr}").into());
+        }
+
+        let rev = self
+            .git_cmd()
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&work_copy)
+            .output()?;
+        Ok(String::from_utf8_lossy(&rev.stdout).trim().to_string())
+    }
+
     /// Run submod command with given arguments
     pub fn run_submod(
         &self,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -390,25 +390,24 @@ impl TestHarness {
             return git_path.join("info").join("sparse-checkout");
         } else if git_path.is_file() {
             // Gitlink - read the file to get the actual git directory
-            if let Ok(content) = std::fs::read_to_string(&git_path) {
-                if let Some(git_dir_line) =
+            if let Ok(content) = std::fs::read_to_string(&git_path)
+                && let Some(git_dir_line) =
                     content.lines().find(|line| line.starts_with("gitdir: "))
-                {
-                    let git_dir_path = git_dir_line.strip_prefix("gitdir: ").unwrap().trim();
+            {
+                let git_dir_path = git_dir_line.strip_prefix("gitdir: ").unwrap().trim();
 
-                    // Path might be relative to the submodule directory
-                    let absolute_path = if std::path::Path::new(git_dir_path).is_absolute() {
-                        std::path::PathBuf::from(git_dir_path)
-                    } else {
-                        self.work_dir.join(submodule_path).join(git_dir_path)
-                    };
+                // Path might be relative to the submodule directory
+                let absolute_path = if std::path::Path::new(git_dir_path).is_absolute() {
+                    std::path::PathBuf::from(git_dir_path)
+                } else {
+                    self.work_dir.join(submodule_path).join(git_dir_path)
+                };
 
-                    let sparse_file = absolute_path.join("info").join("sparse-checkout");
+                let sparse_file = absolute_path.join("info").join("sparse-checkout");
 
-                    // Check if the file exists in the actual git directory
-                    if sparse_file.exists() {
-                        return sparse_file;
-                    }
+                // Check if the file exists in the actual git directory
+                if sparse_file.exists() {
+                    return sparse_file;
                 }
             }
         }

--- a/tests/fallback_tests.rs
+++ b/tests/fallback_tests.rs
@@ -4,7 +4,7 @@
 
 //! Tests for the gix→git2 fallback architecture.
 //!
-//! The core design of the git_ops layer is "gix first, git2 fallback, CLI last resort".
+//! The core design of the `git_ops` layer is "gix first, git2 fallback, CLI last resort".
 //! These tests verify that:
 //! - When gix fails, the error propagates and git2 is invoked
 //! - The fallback produces correct results (not silent failures)
@@ -135,7 +135,7 @@ mod fallback_behavior_tests {
         );
     }
 
-    /// Verify set_config_value also uses fallback for 2-part keys.
+    /// Verify `set_config_value` also uses fallback for 2-part keys.
     #[test]
     fn set_config_value_falls_back_for_two_part_keys() {
         let harness = TestHarness::new().expect("harness");
@@ -187,7 +187,7 @@ mod fallback_submodule_tests {
         Ok(remote_url)
     }
 
-    /// add_submodule: gix explicitly doesn't implement this, so it must fall through
+    /// `add_submodule`: gix explicitly doesn't implement this, so it must fall through
     /// to git2, and if that fails, to CLI. Verify the result is correct.
     #[test]
     fn add_submodule_works_through_fallback() {
@@ -241,7 +241,7 @@ mod fallback_submodule_tests {
         );
     }
 
-    /// list_submodules should work regardless of which backend handles it.
+    /// `list_submodules` should work regardless of which backend handles it.
     #[test]
     fn list_submodules_after_add() {
         let harness = TestHarness::new().expect("harness");
@@ -252,7 +252,7 @@ mod fallback_submodule_tests {
         assert!(!subs.is_empty(), "should list the added submodule");
     }
 
-    /// apply_sparse_checkout has a triple fallback (gix → git2 → CLI).
+    /// `apply_sparse_checkout` has a triple fallback (gix → git2 → CLI).
     /// Both gix and git2 fail for this, so it must reach the CLI fallback.
     /// With a valid submodule path, the CLI fallback should succeed.
     #[test]
@@ -314,7 +314,7 @@ mod fallback_submodule_tests {
 mod backend_consistency_tests {
     use super::*;
 
-    /// Both backends should return the same result for read_gitmodules
+    /// Both backends should return the same result for `read_gitmodules`
     /// on the same repository state.
     #[test]
     fn read_gitmodules_consistent_across_backends() {
@@ -514,7 +514,7 @@ mod error_propagation_tests {
         );
     }
 
-    /// gix fetch_submodule on an invalid path should return Err.
+    /// gix `fetch_submodule` on an invalid path should return Err.
     #[test]
     fn gix_fetch_submodule_propagates_error() {
         let harness = TestHarness::new().expect("harness");
@@ -529,7 +529,7 @@ mod error_propagation_tests {
         );
     }
 
-    /// git2 fetch_submodule on an invalid path should return Err.
+    /// git2 `fetch_submodule` on an invalid path should return Err.
     #[test]
     fn git2_fetch_submodule_propagates_error() {
         let harness = TestHarness::new().expect("harness");
@@ -913,7 +913,7 @@ mod git2_fallback_injection_tests {
         );
     }
 
-    /// reopen() hazard (P0-1): in a single process, add → delete → reopen →
+    /// `reopen()` hazard (P0-1): in a single process, add → delete → reopen →
     /// re-add the same name+path must succeed and re-stage a gitlink. This
     /// exercises `GitOpsManager::reopen()` in-process, which refreshes the
     /// cached git2 repository so the re-add sees the post-delete state.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -195,6 +195,134 @@ sparse_paths = ["src"]
         assert!(stdout.contains("Updated") || stdout.contains("Already up to date"));
     }
 
+    /// `update` must check the submodule worktree out to the commit recorded as
+    /// the superproject's gitlink — the defining job of `git submodule update`.
+    /// Regression test for the gix path silently treating checkout as a no-op
+    /// (it fetched but never moved the worktree), which left the submodule
+    /// stuck behind its recorded commit (#62 P1).
+    #[test]
+    fn update_checks_out_recorded_gitlink_commit() {
+        let harness = TestHarness::new().expect("Failed to create test harness");
+        harness.init_git_repo().expect("Failed to init git repo");
+
+        let remote_repo = harness
+            .create_test_remote("upd_pin")
+            .expect("Failed to create remote");
+        let remote_url = format!("file://{}", remote_repo.display());
+
+        harness
+            .run_submod_success(&["add", &remote_url, "--name", "upd-pin", "--path", "lib/upd"])
+            .expect("Failed to add submodule");
+
+        // C1 = the commit the submodule was added at.
+        let c1 = harness.git_stdout(&["-C", "lib/upd", "rev-parse", "HEAD"]);
+
+        // Create a second commit C2 inside the submodule, record it as the
+        // superproject's gitlink, then move the worktree back to C1 so the
+        // recorded gitlink is *ahead* of the checked-out worktree.
+        fs::write(harness.work_dir.join("lib/upd/NEW.txt"), "new content\n")
+            .expect("Failed to write file in submodule");
+        harness.git_stdout(&["-C", "lib/upd", "add", "."]);
+        harness.git_stdout(&["-C", "lib/upd", "commit", "-m", "c2"]);
+        let c2 = harness.git_stdout(&["-C", "lib/upd", "rev-parse", "HEAD"]);
+        assert_ne!(c1, c2, "the two submodule commits must differ");
+
+        harness.git_stdout(&["add", "lib/upd"]); // record gitlink at C2
+        harness.git_stdout(&["-C", "lib/upd", "checkout", &c1]); // worktree back to C1
+
+        // Preconditions (guard against a vacuous pass): worktree behind the
+        // recorded gitlink, which itself is a staged submodule pointing at C2.
+        assert_eq!(
+            harness.git_stdout(&["-C", "lib/upd", "rev-parse", "HEAD"]),
+            c1,
+            "precondition: submodule worktree must start at C1"
+        );
+        assert_eq!(
+            harness.index_gitlink_mode("lib/upd").as_deref(),
+            Some("160000"),
+            "precondition: lib/upd must be a staged submodule"
+        );
+        assert!(
+            harness
+                .git_stdout(&["ls-files", "--stage", "lib/upd"])
+                .contains(&c2),
+            "precondition: the recorded gitlink must point at C2"
+        );
+
+        harness
+            .run_submod_success(&["update"])
+            .expect("Failed to run update");
+
+        // update must have checked the worktree out to the recorded commit C2.
+        assert_eq!(
+            harness.git_stdout(&["-C", "lib/upd", "rev-parse", "HEAD"]),
+            c2,
+            "update must checkout the superproject-recorded gitlink commit (C2)"
+        );
+        assert!(
+            harness.file_exists("lib/upd/NEW.txt"),
+            "C2's tree must be materialized in the worktree after update"
+        );
+    }
+
+    /// Characterizes `update` against a remote that has moved forward: the fetch
+    /// genuinely happens (the new commit's object is pulled into the submodule),
+    /// but HEAD follows the superproject-recorded gitlink — it does NOT jump to
+    /// the remote tip. That is plain `git submodule update` semantics (only
+    /// `--remote` would follow the branch tip). Replaces the prior no-op smoke
+    /// test that updated against a remote which never advanced (#62 P1).
+    #[test]
+    fn update_against_advanced_remote_fetches_without_moving_head() {
+        let harness = TestHarness::new().expect("Failed to create test harness");
+        harness.init_git_repo().expect("Failed to init git repo");
+
+        let remote_repo = harness
+            .create_test_remote("upd_adv")
+            .expect("Failed to create remote");
+        let remote_url = format!("file://{}", remote_repo.display());
+
+        harness
+            .run_submod_success(&["add", &remote_url, "--name", "upd-adv", "--path", "lib/adv"])
+            .expect("Failed to add submodule");
+
+        // The recorded gitlink and the worktree both start at this commit.
+        let recorded = harness.git_stdout(&["-C", "lib/adv", "rev-parse", "HEAD"]);
+
+        // Move the remote forward; the new commit is not yet known locally.
+        let advanced = harness
+            .advance_test_remote("upd_adv")
+            .expect("Failed to advance remote");
+        assert_ne!(recorded, advanced, "the remote must have actually moved");
+        assert!(
+            harness
+                .git_stdout(&["-C", "lib/adv", "cat-file", "-t", &advanced])
+                .is_empty(),
+            "precondition: the advanced commit must be unknown before update"
+        );
+
+        harness
+            .run_submod_success(&["update"])
+            .expect("Failed to run update");
+
+        // The fetch really ran: the advanced commit's object is now present in
+        // the submodule's object store. (This is the non-vacuous part — it is
+        // false unless update actually fetched, since the object was absent in
+        // the precondition above.)
+        assert_eq!(
+            harness.git_stdout(&["-C", "lib/adv", "cat-file", "-t", &advanced]),
+            "commit",
+            "update must fetch the advanced remote commit into the submodule"
+        );
+
+        // But HEAD stayed at the recorded gitlink — update tracks the recorded
+        // commit, not the remote tip.
+        assert_eq!(
+            harness.git_stdout(&["-C", "lib/adv", "rev-parse", "HEAD"]),
+            recorded,
+            "HEAD must stay at the recorded gitlink, not jump to the remote tip"
+        );
+    }
+
     #[test]
     fn test_reset_command() {
         let harness = TestHarness::new().expect("Failed to create test harness");


### PR DESCRIPTION
## Summary

Addresses the lead **P1** item from the test-suite audit (#62): _"`update` against an advanced remote is untested."_ Probing the real binary while writing the test surfaced a **masked bug**, so this PR is a TDD bug-fix plus a characterization test.

### The bug
`submod update` **fetched but never checked the submodule worktree out** to the commit recorded as the superproject's gitlink — the defining job of `git submodule update`. The gix update path treated the checkout step as a literal no-op (`// Fetch complete above`), and because gix *succeeded*, git2's `submodule.update()` (which performs the checkout) was never reached. Submodules silently stayed stranded behind their recorded commit.

### The fix
The gix path now delegates the `Checkout`/`Unspecified` strategies to git2 (mirroring the existing `Merge`/`Rebase` fallback). git2's `submodule.update()` checks the worktree out to the recorded commit. **11-line production change**, fully within the established gix→git2 fallback design.

## Tests (TDD)
- **`update_checks_out_recorded_gitlink_commit`** — drove the fix (watched RED → GREEN): records the gitlink *ahead* of the worktree, runs `update`, asserts the worktree advanced to the recorded commit (and its tree materialized). Preconditions guard against a vacuous pass.
- **`update_against_advanced_remote_fetches_without_moving_head`** — characterizes `update` against a remote that moved forward: the fetch genuinely pulls the new commit's object (non-vacuous: the object is absent in the precondition, present after), but HEAD follows the **recorded gitlink**, not the remote tip — i.e. plain `git submodule update`, not `--remote`.
- **`TestHarness::advance_test_remote`** helper to move a test remote forward by one commit.

## Verification
- RED→GREEN confirmed for the bug-fix test.
- Full suite: **536 tests pass** (534 + 2 new). The gix-update delegation does not regress `sync`/`init`, which share the path.
- `cargo fmt` clean; `cargo clippy --all-features --tests` introduces no new warnings.

## Scope note
The advanced-remote characterization deliberately locks current (correct, non-`--remote`) semantics: HEAD tracks the recorded gitlink. Remaining P1 audit items (`is_dirty` stub, CLI-over-file precedence, append-only `save_config`) are separate follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)