### PR TITLE
fix(check): report submodules with uncommitted changes as dirty (#62 P1)

### DIFF
--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -375,16 +375,11 @@ impl GitManager {
         let submodule_repo =
             gix::open(submodule_path).map_err(|_| SubmoduleError::RepositoryError)?;
 
-        // GITOXIDE API: Use gix for what's available, fall back to CLI for complex status
-        // For now, use a simple approach - check if there are any uncommitted changes
-        let is_dirty = match submodule_repo.head() {
-            Ok(_head) => {
-                // Simple check - if we can get head, assume repository is clean
-                // This is a conservative approach until we can use the full status API
-                false
-            }
-            Err(_) => true,
-        };
+        // GITOXIDE API: Determine whether the worktree has uncommitted changes.
+        // `is_dirty()` runs the real status computation (modified tracked files
+        // and untracked files alike). If it cannot be determined, conservatively
+        // report dirty so a potential problem is surfaced rather than hidden.
+        let is_dirty = submodule_repo.is_dirty().unwrap_or(true);
 
         // GITOXIDE API: Use reference APIs for current commit
         let current_commit = match submodule_repo.head() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -323,6 +323,70 @@ sparse_paths = ["src"]
         );
     }
 
+    /// `check` must report a submodule whose worktree has uncommitted changes as
+    /// dirty. Regression test for `is_dirty` being a stub that always reported
+    /// clean when HEAD resolved (`src/git_manager.rs`), so the status command
+    /// could never surface a modified working tree (#62 P1).
+    #[test]
+    fn check_reports_dirty_submodule_worktree() {
+        let harness = TestHarness::new().expect("Failed to create test harness");
+        harness.init_git_repo().expect("Failed to init git repo");
+
+        let remote_repo = harness
+            .create_test_remote("dirty_lib")
+            .expect("Failed to create remote");
+        let remote_url = format!("file://{}", remote_repo.display());
+
+        harness
+            .run_submod_success(&[
+                "add",
+                &remote_url,
+                "--name",
+                "dirty-lib",
+                "--path",
+                "lib/dirty",
+            ])
+            .expect("Failed to add submodule");
+
+        // Precondition (guards against a vacuous pass): a clean worktree is
+        // reported clean. If this ever fails, the dirty assertion below would
+        // be meaningless.
+        let clean_out = harness
+            .run_submod_success(&["check", "--verbose"])
+            .expect("Failed to run check on clean submodule");
+        assert!(
+            clean_out.contains("Working tree is clean"),
+            "precondition: a freshly-added submodule must report a clean worktree, got:\n{clean_out}"
+        );
+
+        // Modify a tracked file in the submodule worktree without committing.
+        fs::write(
+            harness.work_dir.join("lib/dirty/LICENSE"),
+            "MIT License\nlocal edit\n",
+        )
+        .expect("Failed to dirty submodule worktree");
+
+        // Precondition: git itself sees the worktree as dirty.
+        assert!(
+            !harness
+                .git_stdout(&["-C", "lib/dirty", "status", "--porcelain"])
+                .is_empty(),
+            "precondition: the submodule worktree must be dirty per git"
+        );
+
+        let dirty_out = harness
+            .run_submod_success(&["check", "--verbose"])
+            .expect("Failed to run check on dirty submodule");
+        assert!(
+            dirty_out.contains("Working tree has changes"),
+            "check must report the modified submodule worktree as dirty, got:\n{dirty_out}"
+        );
+        assert!(
+            !dirty_out.contains("Working tree is clean"),
+            "check must not report the modified submodule worktree as clean, got:\n{dirty_out}"
+        );
+    }
+
     #[test]
     fn test_reset_command() {
         let harness = TestHarness::new().expect("Failed to create test harness");


### PR DESCRIPTION
## What & why

`submod check` reported **every** submodule's working tree as clean, regardless of uncommitted changes. `check_submodule_repository_status` (`src/git_manager.rs`) computed `is_dirty` from a stub that hard-coded `false` whenever HEAD resolved:

```rust
let is_dirty = match submodule_repo.head() {
    Ok(_head) => false, // "assume repository is clean"
    Err(_) => true,
};
```

So the status command could **never** surface a modified worktree — a real masked bug, exactly the "tests verify narration, not effects" theme of the #62 audit (the prior smoke test only asserted printed substrings, never a dirty state).

## The fix

Replace the stub with gix's real `Repository::is_dirty()` — the same API already used in `gix_ops` for the clean-submodule guard before delete. On error it conservatively reports dirty, so a potential problem is surfaced rather than hidden. 11 lines, no new dependencies, stays within the existing gix usage.

## Test (TDD, RED→GREEN)

`check_reports_dirty_submodule_worktree`:
1. Adds a submodule, asserts `check --verbose` reports **"Working tree is clean"** — a non-vacuous guard so the dirty assertion can't pass trivially.
2. Modifies a tracked file in the submodule worktree (no commit).
3. Asserts git itself sees the dirt (`status --porcelain` non-empty) — precondition.
4. Asserts `check --verbose` now reports **"Working tree has changes"** and *not* "clean".

Watched it fail against the stub (still printed "clean" after the edit), then pass after the fix.

## Verification

- RED→GREEN confirmed.
- Full suite **537 pass** (536 + 1), `--no-fail-fast`.
- `check`/`init`/`sync` (which share the status path) unaffected.
- `cargo fmt` + clippy clean (only pre-existing warnings in untouched files).

Part of the #62 P1 test-suite-audit work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)