### PR TITLE
test(config/git_ops): cover git2 option bridges + get_submodule_status OIDs/flags (#62 P1)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2404,4 +2404,99 @@ update = "rebase"
 
         assert!(config.get_submodule("non-existent").is_none());
     }
+
+    // ================================================================
+    // git2 option bridges: Git2SubmoduleOptions / SubmoduleUpdateOptions
+    // (#62 P1 — these conversions ship into every git2-backed add/update
+    // but had no test coverage.)
+    // ================================================================
+
+    #[test]
+    fn test_git2_options_try_from_maps_every_field() {
+        let opts = SubmoduleGitOptions::new(
+            Some(SerializableIgnore::All),
+            Some(SerializableFetchRecurse::Always),
+            Some(SerializableBranch::Name("feature".to_string())),
+            Some(SerializableUpdate::Rebase),
+        );
+        let git2 = Git2SubmoduleOptions::try_from(opts).expect("conversion should succeed");
+        assert_eq!(git2.ignore, git2::SubmoduleIgnore::All);
+        assert_eq!(git2.update, git2::SubmoduleUpdate::Rebase);
+        assert_eq!(git2.branch.as_deref(), Some("feature"));
+        // fetch_recurse bridges through `to_gitmodules` → git's `true`/`false`
+        // encoding, NOT the `always`/`never` serde spelling.
+        assert_eq!(git2.fetch_recurse.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_git2_options_try_from_none_uses_git2_defaults() {
+        let opts = SubmoduleGitOptions::new(None, None, None, None);
+        let git2 = Git2SubmoduleOptions::try_from(opts).expect("conversion should succeed");
+        // Absent ignore/update become git2's neutral sentinels, not a panic.
+        assert_eq!(git2.ignore, git2::SubmoduleIgnore::Unspecified);
+        assert_eq!(git2.update, git2::SubmoduleUpdate::Default);
+        assert_eq!(git2.branch, None);
+        assert_eq!(git2.fetch_recurse, None);
+    }
+
+    #[test]
+    fn test_git2_options_fetch_recurse_on_demand_encoding() {
+        // OnDemand must NOT collapse to the same string as Always — proves the
+        // bridge preserves the distinction git cares about.
+        let opts =
+            SubmoduleGitOptions::new(None, Some(SerializableFetchRecurse::OnDemand), None, None);
+        let git2 = Git2SubmoduleOptions::try_from(opts).expect("conversion should succeed");
+        assert_eq!(git2.fetch_recurse.as_deref(), Some("on-demand"));
+    }
+
+    #[test]
+    fn test_update_options_from_options_recursive_only_when_fetch_always() {
+        // fetchRecurse = always is the one value that flips `recursive` on.
+        let always = SubmoduleUpdateOptions::from_options(SubmoduleGitOptions::new(
+            None,
+            Some(SerializableFetchRecurse::Always),
+            None,
+            Some(SerializableUpdate::Merge),
+        ));
+        assert!(always.recursive, "fetchRecurse=always must set recursive");
+        assert_eq!(always.strategy, SerializableUpdate::Merge);
+        assert!(!always.force, "from_options never forces");
+
+        // Every other fetch_recurse value (incl. None) leaves recursive off.
+        for fr in [
+            None,
+            Some(SerializableFetchRecurse::OnDemand),
+            Some(SerializableFetchRecurse::Never),
+        ] {
+            let opts = SubmoduleUpdateOptions::from_options(SubmoduleGitOptions::new(
+                None, fr, None, None,
+            ));
+            assert!(
+                !opts.recursive,
+                "only fetchRecurse=always should set recursive, got {fr:?}"
+            );
+            // An absent update strategy falls back to the Checkout default.
+            assert_eq!(opts.strategy, SerializableUpdate::Checkout);
+        }
+    }
+
+    #[test]
+    fn test_entry_to_git2_options_reflects_entry_git_options() {
+        let entry = SubmoduleEntry::new(
+            Some("https://example.com/repo.git".to_string()),
+            Some("libs/repo".to_string()),
+            None,
+            Some(SerializableIgnore::Dirty),
+            Some(SerializableUpdate::Checkout),
+            None,
+            Some(true),
+            None,
+            None,
+        );
+        let git2 = entry
+            .to_git2_options()
+            .expect("to_git2_options should succeed");
+        assert_eq!(git2.ignore, git2::SubmoduleIgnore::Dirty);
+        assert_eq!(git2.update, git2::SubmoduleUpdate::Checkout);
+    }
 }

--- a/tests/git_ops_tests.rs
+++ b/tests/git_ops_tests.rs
@@ -336,6 +336,55 @@ mod git2_ops_tests {
             .expect("get_submodule_status");
         assert_eq!(status.path, "lib/statussub");
         assert!(!status.name.is_empty(), "name should not be empty");
+
+        // The OIDs and status flags are the substance of `get_submodule_status`,
+        // yet were previously never asserted (#62 P1). Pin them against the real
+        // git state of a freshly added submodule.
+
+        // Index OID: the gitlink recorded in the superproject index.
+        let stage = harness.git_stdout(&["ls-files", "--stage", "--", "lib/statussub"]);
+        let gitlink_oid = stage
+            .split_whitespace()
+            .nth(1)
+            .expect("ls-files --stage should report the gitlink OID");
+        assert_eq!(
+            status.index_oid.as_deref(),
+            Some(gitlink_oid),
+            "index_oid must equal the staged gitlink OID"
+        );
+
+        // Workdir OID: the commit the submodule worktree is actually checked out
+        // at. For a fresh add it equals the recorded gitlink.
+        let workdir_head = harness.git_stdout(&["-C", "lib/statussub", "rev-parse", "HEAD"]);
+        assert_eq!(
+            status.workdir_oid.as_deref(),
+            Some(workdir_head.as_str()),
+            "workdir_oid must equal the submodule worktree HEAD"
+        );
+        assert_eq!(
+            status.index_oid, status.workdir_oid,
+            "a freshly added submodule's worktree must sit at the recorded gitlink"
+        );
+
+        // Status flags: the submodule is staged in the index, recorded in
+        // `.gitmodules`, and populated in the working directory.
+        assert!(
+            status.status_flags.contains(SubmoduleStatusFlags::IN_INDEX),
+            "IN_INDEX must be set, got {:?}",
+            status.status_flags
+        );
+        assert!(
+            status
+                .status_flags
+                .contains(SubmoduleStatusFlags::IN_CONFIG),
+            "IN_CONFIG must be set, got {:?}",
+            status.status_flags
+        );
+        assert!(
+            status.status_flags.contains(SubmoduleStatusFlags::IN_WD),
+            "IN_WD must be set, got {:?}",
+            status.status_flags
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the **last two untested P1 items** from the #62 test-suite audit. Both target the git2 backend layer, which the suite exercised for *narration* but not for the values it actually computes.

## What this adds

**git2 option bridges (`src/config.rs`)** — these conversions feed every git2-backed `add`/`update` but had zero coverage:
- `Git2SubmoduleOptions::try_from(SubmoduleGitOptions)` — every field mapped; `None` → git2 neutral sentinels (`SubmoduleIgnore::Unspecified` / `SubmoduleUpdate::Default`), not a panic.
- `fetchRecurse` encoding — bridges through `to_gitmodules` to git's `true`/`on-demand`, **distinct** from the serde `always`/`never` spelling (the exact class of mismatch that caused P0-3).
- `SubmoduleUpdateOptions::from_options` recursive-flag logic — only `fetchRecurse=always` flips `recursive` on; everything else (incl. `None`) leaves it off.
- `SubmoduleEntry::to_git2_options` delegates correctly.

**`get_submodule_status` OIDs/flags (`tests/git_ops_tests.rs`)** — `test_with_submodule_get_status` previously asserted only `path`/`name`. Now pins the substance against real git state:
- `index_oid` == the staged gitlink OID (`git ls-files --stage`)
- `workdir_oid` == the submodule worktree HEAD (`git rev-parse`)
- `IN_INDEX | IN_CONFIG | IN_WD` set

A `None` OID — the masked-bug concern the audit flagged — now fails the test.

## Verification
- Full suite: **555 pass, 0 fail**.
- `fmt` + `clippy --all-features --tests` clean on touched code (only pre-existing dead-code warnings remain).
- New assertions are non-vacuous: the `All`-input and `None`→`Unspecified` bridge tests cross-check each other, and the OID assertions compare against live `git` output.

With this, every P1 item in #62 is now addressed (the remaining audit work is P0/P2/P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)