### PR TITLE
test(p2): make cannot-fail error tests meaningful + un-fake null-byte (#62 P2)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,7 +5,6 @@
 //! Common utilities for integration tests
 
 use std::fs;
-use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
@@ -255,18 +254,10 @@ impl TestHarness {
         &self,
         args: &[&str],
     ) -> Result<std::process::Output, Box<dyn std::error::Error>> {
-        // Check for null bytes in arguments which would cause process execution to fail
-        for arg in args {
-            if arg.contains('\0') {
-                // Return a simulated failed output for null byte arguments
-                return Ok(std::process::Output {
-                    status: std::process::ExitStatus::from_raw(1),
-                    stdout: Vec::new(),
-                    stderr: b"Error: Invalid argument contains null byte\n".to_vec(),
-                });
-            }
-        }
-
+        // NOTE: arguments containing an interior NUL byte cannot be passed to a
+        // process at all — std's Command rejects them before spawn, so `.output()`
+        // below returns an Err. We deliberately do NOT fabricate a fake failure
+        // here; tests assert the real process-boundary rejection.
         let output = Command::new(&self.submod_bin)
             .args(args)
             .current_dir(&self.work_dir)

--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -69,13 +69,34 @@ mod tests {
         let harness = TestHarness::new().expect("Failed to create test harness");
         harness.init_git_repo().expect("Failed to init git repo");
 
-        // Try to use a non-existent config file
-        harness
+        // A non-existent config path is handled gracefully: `check` falls back to
+        // defaults and exits 0 (there are no submodules to report on).
+        let missing = harness
             .run_submod(&["--config", "/nonexistent/path/config.toml", "check"])
             .expect("Failed to run submod");
+        assert!(
+            missing.status.success(),
+            "a missing config file should be handled gracefully, exit was {:?}; stderr: {}",
+            missing.status.code(),
+            String::from_utf8_lossy(&missing.stderr)
+        );
 
-        // Should handle missing config file gracefully (create default or error)
-        // The exact behavior depends on implementation
+        // A config file that exists but is malformed must NOT be swallowed: it
+        // fails with a specific parse diagnostic, not a generic catch-all.
+        let bad_config = harness.work_dir.join("bad.toml");
+        fs::write(&bad_config, "this is = = not toml [[[\n").expect("write bad config");
+        let malformed = harness
+            .run_submod(&["--config", "bad.toml", "check"])
+            .expect("Failed to run submod");
+        assert!(
+            !malformed.status.success(),
+            "a malformed config must cause a non-zero exit"
+        );
+        let stderr = String::from_utf8_lossy(&malformed.stderr);
+        assert!(
+            stderr.contains("TOML parse error") || stderr.contains("parse error"),
+            "malformed config error must name the parse failure, got: {stderr}"
+        );
     }
 
     #[test]
@@ -202,16 +223,25 @@ mod tests {
             .expect("Failed to create remote");
         let remote_url = format!("file://{}", remote_repo.display());
 
-        // Test various potentially problematic sparse patterns
-        let problematic_patterns = vec![
-            "//invalid//path",
-            "..",
-            "../../../escape",
-            "path/with/\0/null",
-        ];
+        // A path-traversal sentinel: if any pattern lets the tool write outside the
+        // superproject working tree, this file/dir would appear one level up.
+        let escape_sentinel = harness
+            .work_dir
+            .parent()
+            .expect("work_dir has a parent")
+            .join("escape");
+        assert!(
+            !escape_sentinel.exists(),
+            "sentinel must not pre-exist before the test"
+        );
 
-        for pattern in problematic_patterns {
-            let output = harness
+        // Traversal / malformed patterns. The security-relevant property is
+        // CONTAINMENT: regardless of success or failure, nothing is written
+        // outside the superproject working tree.
+        let traversal_patterns = vec!["//invalid//path", "..", "../../../escape", "../escape"];
+
+        for pattern in traversal_patterns {
+            let _output = harness
                 .run_submod(&[
                     "add",
                     &remote_url,
@@ -224,15 +254,41 @@ mod tests {
                 ])
                 .expect("Failed to run submod");
 
-            // Should either succeed and handle the pattern safely, or fail gracefully
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                assert!(!stderr.is_empty());
-            }
+            // Containment: the traversal pattern must never materialize a path
+            // outside the working tree, nor at an absolute system location.
+            assert!(
+                !escape_sentinel.exists(),
+                "path traversal escaped the working tree for pattern {pattern:?}: {} was created",
+                escape_sentinel.display()
+            );
+            assert!(
+                !std::path::Path::new("/escape").exists(),
+                "path traversal reached an absolute location for pattern {pattern:?}"
+            );
 
             // Clean up for next iteration
             let _ = fs::remove_dir_all(harness.work_dir.join("lib/sparse-test"));
         }
+
+        // A NUL byte in an argument cannot be handed to a process at all: std's
+        // Command rejects it before spawn, so run_submod returns an Err. Assert
+        // that real boundary rejection (previously faked by the harness).
+        let nul_result = harness.run_submod(&[
+            "add",
+            &remote_url,
+            "--name",
+            "sparse-test",
+            "--path",
+            "lib/sparse-test",
+            "--sparse-paths",
+            "path/with/\0/null",
+        ]);
+        let err =
+            nul_result.expect_err("a NUL-byte argument must be rejected at the process boundary");
+        assert!(
+            err.to_string().to_lowercase().contains("nul"),
+            "expected a NUL-byte rejection error, got: {err}"
+        );
     }
 
     #[test]

--- a/tests/sparse_checkout_tests.rs
+++ b/tests/sparse_checkout_tests.rs
@@ -327,31 +327,35 @@ sparse_paths = ["src", "docs", "*.md"]
             .expect("Failed to create remote");
         let remote_url = format!("file://{}", remote_repo.display());
 
-        // Try to add with empty sparse paths - should handle gracefully
-        let output = harness.run_submod(&[
-            "add",
-            &remote_url,
-            "--name",
-            "sparse-empty",
-            "--path",
-            "lib/sparse-empty",
-            "--sparse-paths",
-            "",
-        ]);
+        // Adding with an empty sparse-paths value succeeds and simply does not
+        // enable sparse checkout (an empty pattern set is a no-op, not an error).
+        let output = harness
+            .run_submod(&[
+                "add",
+                &remote_url,
+                "--name",
+                "sparse-empty",
+                "--path",
+                "lib/sparse-empty",
+                "--sparse-paths",
+                "",
+            ])
+            .expect("Failed to run submod");
 
-        // Should either succeed without sparse checkout or provide clear error
-        if let Ok(process_output) = output {
-            if process_output.status.success() {
-                // If successful, sparse checkout should not be enabled
-                let sparse_file = harness.get_sparse_checkout_file_path("lib/sparse-empty");
-                assert!(
-                    !sparse_file.exists()
-                        || fs::read_to_string(&sparse_file).unwrap().trim().is_empty()
-                );
-            }
-        } else {
-            // If it fails, that's also acceptable for empty patterns
-        }
+        assert!(
+            output.status.success(),
+            "empty sparse-paths should be a graceful no-op, exit was {:?}; stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // Sparse checkout must not be enabled: either no sparse-checkout file, or
+        // an empty one.
+        let sparse_file = harness.get_sparse_checkout_file_path("lib/sparse-empty");
+        assert!(
+            !sparse_file.exists() || fs::read_to_string(&sparse_file).unwrap().trim().is_empty(),
+            "empty sparse-paths must not enable a non-empty sparse checkout"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Addresses the #62 audit's P2 bullet **"Tests that cannot fail meaningfully — delete or fix"**, plus the P2 security note that **null-byte handling is faked by the harness**.

### Un-fake the null byte
`TestHarness::run_submod` previously intercepted any arg containing `\0` and **returned a fabricated failure without launching the binary** (`tests/common/mod.rs`). Removed. std's `Command` rejects interior NUL bytes *before spawn*, so the honest behavior is an `Err` at the process boundary — tests now assert that real rejection. (`ExitStatusExt` import dropped as now-unused.)

### Strengthened tests (probed against the real binary first, so non-vacuous)

| Test | Before | After |
|---|---|---|
| `test_invalid_config_file_path` | **zero assertions** | missing `--config` → graceful exit 0; **malformed** config → non-zero exit with a specific `parse error` diagnostic |
| `test_invalid_sparse_checkout_patterns` | only `assert!(!stderr.is_empty())` | path-traversal **containment**: a sentinel never appears outside the working tree nor at `/escape` for `..`/`../../../escape`/`../escape`; NUL byte → real boundary `Err` |
| `test_sparse_checkout_empty_patterns` | `else { /* failure also acceptable */ }` escape | requires success **and** that no non-empty sparse checkout is enabled |

## Verification

Full suite **555 pass, 0 fail**; `cargo fmt` + `clippy --all-features --tests` clean.

## Scope / follow-ups

This is the tractable slice of the P2 "cannot-fail" bullet. Still open in P2 (separate PRs): remaining `assert!(!stderr.is_empty())` sites in other tests, wide `||` error-message disjunctions + exit-code assertions, the root-no-op permission/lock tests, the broader security vectors (URL/name flag-injection, malicious `.gitmodules` to `generate-config`, symlink escapes), and idempotency/partial-failure tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)