### PR TITLE
ci: run all four cargo-deny checks, not just advisories

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -11,13 +11,23 @@ local linters = new Mapping<String, Step> {
 
     ["cargo_deny"] = new Step {
         workspace_indicator = "Cargo.toml"
-        glob = "Cargo.lock"
-        // Gate on vulnerabilities only, letting cargo-deny's own exit code decide.
+        // All three inputs matter now that every check runs: `licenses` and `bans`
+        // read Cargo.toml, and all four read deny.toml. With only Cargo.lock here,
+        // editing the policy itself would not re-run the step that enforces it.
+        glob = List("Cargo.lock", "Cargo.toml", "deny.toml")
+        // `check` with no subcommand runs all four — advisories, bans, licenses,
+        // sources — letting cargo-deny's own exit code decide. This was
+        // `check advisories` with `-A unsound -A unmaintained -A yanked -A notice`,
+        // which meant `deny.toml`'s licenses/bans/sources policy was configured but
+        // never enforced by any hook or CI job. The four allowances are gone too:
+        // they suppress nothing in the current graph, so keeping them would only
+        // hide a *future* unmaintained or yanked dependency. If one lands, add it to
+        // `ignore` in deny.toml with a reason rather than reinstating a blanket -A.
         // (The previous `-f json ... | jq -e '.[].vulnerabilities | length == 0'`
         // pipeline no longer parses: with `-f json` cargo-deny streams one object
         // per diagnostic, not an array, so jq failed with exit 5 on every run.)
         // --exclude-dev is a top-level flag; it moved off the `check` subcommand.
-        check = "cargo deny --all-features --manifest-path {{ workspace_indicator }} --exclude-dev -L warn check advisories --hide-inclusion-graph -A unsound -A unmaintained -A yanked -A notice"
+        check = "cargo deny --all-features --manifest-path {{ workspace_indicator }} --exclude-dev -L warn check --hide-inclusion-graph"
     }
     ["cargo_fmt"] = Builtins.cargo_fmt
     ["cargo_clippy"] = Builtins.cargo_clippy


### PR DESCRIPTION
`deny.toml` configures advisories, licenses, bans and sources. The hk `cargo_deny` step ran only `check advisories`, so three of those four sections were policy nobody enforced — the same shape as the CI job that reported success across three toolchains while running zero tests.

## Changes

- `check advisories` → `check` (all four checks)
- Dropped `-A unsound -A unmaintained -A yanked -A notice`. They suppress nothing in the current graph; keeping them would only hide a *future* unmaintained or yanked dependency. `RUSTSEC-2024-0364` stays handled by ID in `deny.toml`'s `ignore`, where the reason is recorded.
- Glob widened `Cargo.lock` → `Cargo.lock`, `Cargo.toml`, `deny.toml`. `licenses`/`bans` read `Cargo.toml` and all four read `deny.toml`, so editing the policy has to re-run the step that enforces it.

`.github/workflows/ci.yml` needs no change — the lint job runs `hk check --all`, so it inherits this.

## Verification

Full check on `main` is clean, with and without the allowances:

```
advisories ok, bans ok, licenses ok, sources ok
```

And it fails when policy is violated — dropping `MIT` from the allow list:

```
advisories ok, bans ok, licenses FAILED, sources ok
```

The previous command reported `advisories ok` and exit 0 on that same graph.

This also closes the `submod = 0.3.0 is unlicensed` failure noted earlier: with `license = "LicenseRef-PlainMIT OR MIT"` in place of `license-file`, cargo-deny resolves the expression through the `MIT` branch. That is now checked on every run rather than only when someone runs `cargo deny check` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XocU6NjgZricrRWMLyLXDn